### PR TITLE
set explicit dependencies

### DIFF
--- a/package/mistify/mistify-agent-image/mistify-agent-image.mk
+++ b/package/mistify/mistify-agent-image/mistify-agent-image.mk
@@ -11,7 +11,7 @@ MISTIFY_AGENT_IMAGE_LICENSE = Apache
 MISTIFY_AGENT_IMAGE_LICENSE_FILES = LICENSE
 MISTIFY_AGENT_IMAGE_DEPENDENCIES = mistify-agent
 
-GOPATH=$(O)/tmp/mistify-agent-image-GOPATH
+GOPATH=$(O)/tmp/GOPATH
 
 define MISTIFY_AGENT_IMAGE_BUILD_CMDS
 	# GO apparently wants the install path to be independent of the

--- a/package/mistify/mistify-agent-libvirt/mistify-agent-libvirt.mk
+++ b/package/mistify/mistify-agent-libvirt/mistify-agent-libvirt.mk
@@ -11,7 +11,7 @@ MISTIFY_AGENT_LIBVIRT_LICENSE = Apache
 MISTIFY_AGENT_LIBVIRT_LICENSE_FILES = LICENSE
 MISTIFY_AGENT_LIBVIRT_DEPENDENCIES = host-libvirt mistify-agent
 
-GOPATH=$(O)/tmp/mistify-agent-libvirt-GOPATH
+GOPATH=$(O)/tmp/GOPATH
 
 define MISTIFY_AGENT_LIBVIRT_BUILD_CMDS
 	# GO apparently wants the install path to be independent of the

--- a/package/mistify/mistify-agent/mistify-agent.mk
+++ b/package/mistify/mistify-agent/mistify-agent.mk
@@ -10,7 +10,7 @@ MISTIFY_AGENT_SITE_METHOD = git
 MISTIFY_AGENT_LICENSE = Apache
 MISTIFY_AGENT_LICENSE_FILES = LICENSE
 
-GOPATH=$(O)/tmp/mistify-agent-GOPATH
+GOPATH=$(O)/tmp/GOPATH
 
 define MISTIFY_AGENT_BUILD_CMDS
 	# GO apparently wants the install path to be independent of the


### PR DESCRIPTION
So that agent repo pulls happen in correct order.
