### PR TITLE
do not daemonize. systemd manages it fine without it.

### DIFF
--- a/package/mistify/libvirt/libvirtd.sysconfig
+++ b/package/mistify/libvirt/libvirtd.sysconfig
@@ -1,5 +1,5 @@
 # options passed to libvirtd, add "-l" to listen on tcp
-LIBVIRTD_ARGS="-d"
+LIBVIRTD_ARGS=""
 
 # pass in location of kerberos keytab
 KRB5_KTNAME=/etc/libvirt/libvirt.keytab


### PR DESCRIPTION
Systemd manages libvirt just fine without it daemonizing.  There is some strangeness with /var/run and libvirt on initial start - perhaps aufs.  This removes one factor. 

Look for a followup to untangle some of the service dependencies.  Restarting libvirtd causes all the agent stuff to stop and not restart...
