### PR TITLE
Dependencies/restarts

### DIFF
--- a/package/mistify/mistify-agent-image/mistify-agent-image.service
+++ b/package/mistify/mistify-agent-image/mistify-agent-image.service
@@ -7,6 +7,8 @@ Type=simple
 EnvironmentFile=/etc/sysconfig/mistify-agent-image
 ExecStart=/opt/mistify/sbin/mistify-agent-image $OPTIONS
 LimitNOFILE=32768
+RestartSec=30s
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/package/mistify/mistify-agent-libvirt/mistify-agent-libvirt.service
+++ b/package/mistify/mistify-agent-libvirt/mistify-agent-libvirt.service
@@ -8,6 +8,8 @@ Type=simple
 EnvironmentFile=/etc/sysconfig/mistify-agent-libvirt
 ExecStart=/opt/mistify/sbin/mistify-agent-libvirt $OPTIONS
 LimitNOFILE=32768
+RestartSec=30s
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/package/mistify/mistify-agent/mistify-agent.service
+++ b/package/mistify/mistify-agent/mistify-agent.service
@@ -8,6 +8,8 @@ Type=simple
 EnvironmentFile=/etc/sysconfig/mistify-agent
 ExecStart=/opt/mistify/sbin/mistify-agent $OPTIONS
 LimitNOFILE=32768
+RestartSec=30s
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The current unit files dependencies are too "strict" - it can lead to a situation where restarting libvirt leaves the entire stack down.  This loosens the dependencies a bit and adds restarts.  Units now depend on the bare minimum to start/run.
