### PR TITLE
UUID changes

### DIFF
--- a/board/mistify/rootfs_overlay/etc/pre-init.d/gen-hostid.sh
+++ b/board/mistify/rootfs_overlay/etc/pre-init.d/gen-hostid.sh
@@ -2,19 +2,39 @@
 # Get the SMBIOS product_uuid and use it for the basis of hostid and machine-id
 # Parts of this script is based on one from Fazle Arefin
 
-if [ -f /sys/class/dmi/id/product_uuid ]; then
-  uuid_file=/sys/class/dmi/id/product_uuid
-else
-  uuid_file=`uuidgen`
+uuid=""
+# uuid passed in?
+read -r cmdline < /proc/cmdline
+for param in $cmdline ; do
+	case $param in
+	    mistify-uuid=*)
+		    uuid=${param#mistify-uuid=}
+		    ;;
+	esac
+done
+
+if [ -z "$uuid" ]; then
+    uuid=`cat /sys/class/dmi/id/product_uuid`
 fi
 
-if [ -f $uuid_file ]; then
-  uuid=`cat $uuid_file | tr '[:upper:]' '[:lower:]'`
-  host_id=${uuid:0:8}
-  machine_id=`sed 's/-//g' <<< $uuid`
-else
-  host_id=$(hostid)
+if [ -z "$uuid" ]; then
+    # try to generate same uuid on each boot
+    mac=`ip link show | awk '/ether/ {print $2}' | sort | head -n 1 | sed s/://g`
+    a=${mac:0:8}
+    b=${mac:8:4}
+    uuid=`printf '%s-%s-0000-0000-000000000000' $A $B`
 fi
+
+if [ -z "$uuid" ]; then
+    echo "unable to get a uuid!"
+    exit -5
+fi
+
+#lowercase the UUID
+uuid=${uuid,,}
+
+machine_id=`sed 's/-//g' <<< $uuid`
+host_id=${uuid:0:8}
 
 a=${host_id:6:2}
 b=${host_id:4:2}
@@ -22,9 +42,15 @@ c=${host_id:2:2}
 d=${host_id:0:2}
 
 echo -ne \\x$a\\x$b\\x$c\\x$d > /etc/hostid &&
-  echo "Setting hostid to $host_id"
+    echo "Setting hostid to $host_id"
 
 echo $machine_id > /etc/machine_id &&
-  echo "Setting machine_id to $machine_id"
+    echo "Setting machine_id to $machine_id"
+
+echo $machine_id > /etc/machine-id &&
+    echo "Setting machine-id to $machine_id"
+
+echo $uuid > /etc/mistify-id  &&
+    echo "Setting mistify-id to $uuid"
 
 exit 0

--- a/board/mistify/rootfs_overlay/etc/pre-init.d/gen-hostid.sh
+++ b/board/mistify/rootfs_overlay/etc/pre-init.d/gen-hostid.sh
@@ -33,7 +33,8 @@ fi
 #lowercase the UUID
 uuid=${uuid,,}
 
-machine_id=`sed 's/-//g' <<< $uuid`
+#remove dashes
+machine_id=${uuid//-/}
 host_id=${uuid:0:8}
 
 a=${host_id:6:2}

--- a/board/mistify/rootfs_overlay/etc/pre-init.d/gen-hostid.sh
+++ b/board/mistify/rootfs_overlay/etc/pre-init.d/gen-hostid.sh
@@ -22,7 +22,7 @@ if [ -z "$uuid" ]; then
     mac=`ip link show | awk '/ether/ {print $2}' | sort | head -n 1 | sed s/://g`
     a=${mac:0:8}
     b=${mac:8:4}
-    uuid=`printf '%s-%s-0000-0000-000000000000' $A $B`
+    uuid=`printf '%s-%s-0000-0000-000000000000' $a $b`
 fi
 
 if [ -z "$uuid" ]; then

--- a/board/mistify/rootfs_overlay/etc/pre-init.d/gen-hostid.sh
+++ b/board/mistify/rootfs_overlay/etc/pre-init.d/gen-hostid.sh
@@ -7,8 +7,8 @@ uuid=""
 read -r cmdline < /proc/cmdline
 for param in $cmdline ; do
 	case $param in
-	    mistify-uuid=*)
-		    uuid=${param#mistify-uuid=}
+	    mistify.uuid=*)
+		    uuid=${param#mistify.uuid=}
 		    ;;
 	esac
 done


### PR DESCRIPTION
Original version would not work if no product_uuid was availible. This also tries to use the MAC of an interface to generate same id on each boot.  Passing in mistify.uuid overrides them all.

un tested, PR opened for comments.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-os/67)
<!-- Reviewable:end -->
