### PR TITLE
Made the network interface wildcard a little more generalized so it

### DIFF
--- a/board/mistify/rootfs_overlay/etc/systemd/network/80-dhcp.network
+++ b/board/mistify/rootfs_overlay/etc/systemd/network/80-dhcp.network
@@ -1,5 +1,5 @@
 [Match]
-Name=eno*
+Name=en*
 
 [Network]
 DHCP=v4


### PR DESCRIPTION
will also pick up the enpXsX devices that qemu creates.
