### PR TITLE
Updated the GO build to pull from the github repo and to default to version 1.4.2.

### DIFF
--- a/scripts/install-go.sh
+++ b/scripts/install-go.sh
@@ -4,9 +4,9 @@
 # the googlesource repo so that URL is the default for this script. Of course
 # it can be overridden using the --gouri command line option.
 #-
-gouridefault=https://go.googlesource.com/go
+gouridefault=git@github.com:golang/go.git
 godirdefault=$PWD/go
-gotagdefault=go1.4.1
+gotagdefault=go1.4.2
 
 install-go () {
     #+
@@ -60,7 +60,7 @@ install-go () {
 
     GOROOT=$godir/$gotag/go
     verbose "The go binaries are located at: $GOROOT"
-    
+
     if [ -f $godir/.$gotag-built ]; then
 	message "Using go version $gotag."
 	return
@@ -91,7 +91,7 @@ install-go () {
 	export CGO_ENABLED=1
 
 	run ./make.bash
-	
+
 	# Clean up
 	unset CC_FOR_TARGET
 	unset CXX_FOR_TARGET


### PR DESCRIPTION
If you're not using a clean checkout of the mistify-os repo then you may need to manually switch to the new default values using the --gouri and --gotag options.

e.g. `./buildmistify --gouri default --gotag default`
