### PR TITLE
Create docker group for docker.socket

### DIFF
--- a/package/mistify/docker-docker/docker-docker-002-service-execstart.patch
+++ b/package/mistify/docker-docker/docker-docker-002-service-execstart.patch
@@ -7,7 +7,7 @@ index bc73448..053408a 100644
  
  [Service]
 -ExecStart=/usr/bin/docker -d -H fd://
-+ExecStart=/usr/bin/docker -d -H fd:// -H unix:///var/run/docker.sock -s zfs --storage-opt zfs.fsname=mistify/guests
++ExecStart=/usr/bin/docker -d -H fd:// -s zfs --storage-opt zfs.fsname=mistify/guests
  MountFlags=slave
  LimitNOFILE=1048576
  LimitNPROC=1048576

--- a/package/mistify/docker-docker/docker-docker.mk
+++ b/package/mistify/docker-docker/docker-docker.mk
@@ -109,6 +109,10 @@ define DOCKER_DOCKER_INSTALL_STAGING_CMDS
 	# when GOPATH moves to staging
 endef
 
+define DOCKER_DOCKER_USERS
+	- - docker -1 * - - - Docker Application Container Framework
+endef
+
 define DOCKER_DOCKER_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/usr/lib/docker
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/var/lib/docker


### PR DESCRIPTION
Also drops the -H option specifying the socket path, since we want systemd to manage the sockets.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-os/90)

<!-- Reviewable:end -->
