### PR TITLE
Toolchain build update

### DIFF
--- a/buildmistify
+++ b/buildmistify
@@ -52,16 +52,13 @@ Usage: ./buildmistify [options] [target]
         toolchain. This is saved in the file
         $statedir/toolchainprefix
         [toolchainprefix=`cat $statedir/toolchainprefix`]
-    --toolchainbranch <label>
-        Checkout the toolchain using a specified branch. NOTE: This option
-        supercedes the --toolchaintag option. The branch name is saved in the
-        file $statedir/toolchainbranch.
-        [toolchainbranch=`cat $statedir/toolchainbranch`]
-    --toolchaintag <tag>
-        Checkout the toolchain using a specific tag. To reset to the master
-        branch use the --toolchainbranch option. The tag is saved in the file
-        $statedir/toolchaintag.
-        [toolchaintag=`cat $statedir/toolchaintag`]
+    --toolchainversion <version>
+        Checkout the toolchain using a specified version. This can be a branch
+        or tag name or even a commit ID. The branch name is saved in the
+        file $statedir/toolchainversion.
+        [toolchainversion=`cat $statedir/toolchainversion`]
+    --toolchainreset
+	Reset the toolchain related options to their defaults.
     ==== go ====
     --godir <dir>
         Where the GO source code is cloned to before building. This is saved in
@@ -192,8 +189,8 @@ a=`getopt -l "\
 tcuri:,\
 toolchaindir:,\
 toolchainprefix:,\
-toolchainbranch:,\
-toolchaintag:,\
+toolchainversion:,\
+toolchainreset,\
 gouri:,\
 godir:,\
 gotag:,\
@@ -241,13 +238,12 @@ while [ $# -ge 1 ]; do
 	    toolchainprefix=$2
 	    shift
 	    ;;
-	--toolchainbranch)
-	    toolchainbranch=$2
+	--toolchainversion)
+	    toolchainversion=$2
 	    shift
 	    ;;
-	--toolchaintag)
-	    toolchaintag=$2
-	    shift
+	--toolchainreset)
+	    toolchainreset=y
 	    ;;
 	--gouri)
 	    gouri=$2

--- a/buildmistify
+++ b/buildmistify
@@ -193,7 +193,7 @@ tcuri:,\
 toolchaindir:,\
 toolchainprefix:,\
 toolchainbranch:,\
-toolchainroottag:,\
+toolchaintag:,\
 gouri:,\
 godir:,\
 gotag:,\

--- a/buildmistify
+++ b/buildmistify
@@ -680,14 +680,6 @@ message "Project dir: $projectdir"
 # Be sure the toolchain is installed.
 #-
 install-toolchain
-if [[ $? -gt 0 ]]; then
-    #+
-    # If the toolchain was built then a full rebuild is needed.
-    #-
-    warning "The toolchain has changed. A full target rebuild is recommended."
-    warning "Run ./buildmistify clean and then ./buildmistify to rebuild."
-    exit
-fi
 install-go
 
 #+

--- a/configs/mistify-tc.config
+++ b/configs/mistify-tc.config
@@ -1,11 +1,10 @@
 #
 # Automatically generated make config: don't edit
-# crosstool-NG 1.20.0 Configuration
-# Tue Mar  3 17:05:04 2015
+# crosstool-NG 1.21.0 Configuration
+# Thu Jun  4 12:41:22 2015
 #
 CT_CONFIGURE_has_make381=y
 CT_CONFIGURE_has_xz=y
-CT_CONFIGURE_has_cvs=y
 CT_CONFIGURE_has_svn=y
 CT_MODULES=y
 
@@ -23,14 +22,13 @@ CT_MODULES=y
 #
 # Paths
 #
-CT_LOCAL_TARBALLS_DIR="${TC_LOCAL_TARBALLS_DIR}"
-CT_SAVE_TARBALLS=y
+CT_LOCAL_TARBALLS_DIR=""
 CT_WORK_DIR="${CT_TOP_DIR}/.build"
-CT_PREFIX_DIR="${TC_PREFIX_DIR}"
+CT_PREFIX_DIR="${HOME}/x-tools/${CT_TARGET}"
 CT_INSTALL_DIR="${CT_PREFIX_DIR}"
 CT_RM_RF_PREFIX_DIR=y
 CT_REMOVE_DOCS=y
-# CT_INSTALL_DIR_RO is not set
+CT_INSTALL_DIR_RO=y
 CT_STRIP_ALL_TOOLCHAIN_EXECUTABLES=y
 
 #
@@ -78,35 +76,31 @@ CT_CONFIG_SHELL="${bash}"
 #
 # CT_LOG_ERROR is not set
 # CT_LOG_WARN is not set
-# CT_LOG_INFO is not set
-CT_LOG_EXTRA=y
+CT_LOG_INFO=y
+# CT_LOG_EXTRA is not set
 # CT_LOG_ALL is not set
 # CT_LOG_DEBUG is not set
-CT_LOG_LEVEL_MAX="EXTRA"
+CT_LOG_LEVEL_MAX="INFO"
 # CT_LOG_SEE_TOOLS_WARN is not set
-# CT_LOG_PROGRESS_BAR is not set
+CT_LOG_PROGRESS_BAR=y
 CT_LOG_TO_FILE=y
 CT_LOG_FILE_COMPRESS=y
 
 #
 # Target options
 #
-CT_ARCH="x86"
+CT_ARCH="alpha"
 CT_ARCH_SUPPORTS_32=y
-CT_ARCH_SUPPORTS_64=y
-CT_ARCH_SUPPORTS_WITH_ARCH=y
 CT_ARCH_SUPPORTS_WITH_CPU=y
 CT_ARCH_SUPPORTS_WITH_TUNE=y
 CT_ARCH_DEFAULT_32=y
-CT_ARCH_ARCH=""
 CT_ARCH_CPU=""
 CT_ARCH_TUNE=""
-# CT_ARCH_32 is not set
-CT_ARCH_64=y
-CT_ARCH_BITNESS=64
+CT_ARCH_32=y
+CT_ARCH_BITNESS=32
 CT_TARGET_CFLAGS=""
 CT_TARGET_LDFLAGS=""
-# CT_ARCH_alpha is not set
+CT_ARCH_alpha=y
 # CT_ARCH_arm is not set
 # CT_ARCH_avr32 is not set
 # CT_ARCH_blackfin is not set
@@ -117,7 +111,7 @@ CT_TARGET_LDFLAGS=""
 # CT_ARCH_s390 is not set
 # CT_ARCH_sh is not set
 # CT_ARCH_sparc is not set
-CT_ARCH_x86=y
+# CT_ARCH_x86 is not set
 CT_ARCH_alpha_AVAILABLE=y
 CT_ARCH_arm_AVAILABLE=y
 CT_ARCH_avr32_AVAILABLE=y
@@ -143,6 +137,17 @@ CT_ARCH_USE_MMU=y
 # Target optimisations
 #
 CT_ARCH_FLOAT=""
+
+#
+# alpha other options
+#
+CT_ARCH_ALPHA_EV4=y
+# CT_ARCH_ALPHA_EV45 is not set
+# CT_ARCH_ALPHA_EV5 is not set
+# CT_ARCH_ALPHA_EV56 is not set
+# CT_ARCH_ALPHA_EV6 is not set
+# CT_ARCH_ALPHA_EV67 is not set
+CT_ARCH_ALPHA_VARIANT="ev4"
 
 #
 # Toolchain options
@@ -189,57 +194,17 @@ CT_BUILD_SUFFIX=""
 #
 # Operating System
 #
-CT_KERNEL_SUPPORTS_SHARED_LIBS=y
-CT_KERNEL="linux"
-CT_KERNEL_VERSION="3.18.7"
-# CT_KERNEL_bare_metal is not set
-CT_KERNEL_linux=y
-# CT_KERNEL_windows is not set
+CT_BARE_METAL=y
+CT_KERNEL="bare-metal"
+CT_KERNEL_bare_metal=y
+# CT_KERNEL_linux is not set
 CT_KERNEL_bare_metal_AVAILABLE=y
 CT_KERNEL_linux_AVAILABLE=y
-CT_KERNEL_V_3_18=y
-# CT_KERNEL_V_3_17 is not set
-# CT_KERNEL_V_3_16 is not set
-# CT_KERNEL_V_3_15 is not set
-# CT_KERNEL_V_3_14 is not set
-# CT_KERNEL_V_3_13 is not set
-# CT_KERNEL_V_3_12 is not set
-# CT_KERNEL_V_3_11 is not set
-# CT_KERNEL_V_3_10 is not set
-# CT_KERNEL_V_3_9 is not set
-# CT_KERNEL_V_3_8 is not set
-# CT_KERNEL_V_3_7 is not set
-# CT_KERNEL_V_3_6 is not set
-# CT_KERNEL_V_3_5 is not set
-# CT_KERNEL_V_3_4 is not set
-# CT_KERNEL_V_3_3 is not set
-# CT_KERNEL_V_3_2 is not set
-# CT_KERNEL_V_3_1 is not set
-# CT_KERNEL_V_3_0 is not set
-# CT_KERNEL_V_2_6_39 is not set
-# CT_KERNEL_V_2_6_38 is not set
-# CT_KERNEL_V_2_6_37 is not set
-# CT_KERNEL_V_2_6_36 is not set
-# CT_KERNEL_V_2_6_33 is not set
-# CT_KERNEL_V_2_6_32 is not set
-# CT_KERNEL_V_2_6_31 is not set
-# CT_KERNEL_V_2_6_27 is not set
-# CT_KERNEL_LINUX_CUSTOM is not set
 CT_KERNEL_windows_AVAILABLE=y
 
 #
 # Common kernel options
 #
-CT_SHARED_LIBS=y
-
-#
-# linux other options
-#
-CT_KERNEL_LINUX_VERBOSITY_0=y
-# CT_KERNEL_LINUX_VERBOSITY_1 is not set
-# CT_KERNEL_LINUX_VERBOSITY_2 is not set
-CT_KERNEL_LINUX_VERBOSE_LEVEL=0
-CT_KERNEL_LINUX_INSTALL_CHECK=y
 
 #
 # Binary utilities
@@ -251,9 +216,9 @@ CT_BINUTILS_binutils=y
 #
 # GNU binutils
 #
-# CT_BINUTILS_SHOW_LINARO is not set
-# CT_BINUTILS_V_2_25 is not set
-CT_BINUTILS_V_2_24=y
+# CT_CC_BINUTILS_SHOW_LINARO is not set
+CT_BINUTILS_V_2_25=y
+# CT_BINUTILS_V_2_24 is not set
 # CT_BINUTILS_V_2_23_2 is not set
 # CT_BINUTILS_V_2_23_1 is not set
 # CT_BINUTILS_V_2_22 is not set
@@ -262,7 +227,8 @@ CT_BINUTILS_V_2_24=y
 # CT_BINUTILS_V_2_20_1a is not set
 # CT_BINUTILS_V_2_19_1a is not set
 # CT_BINUTILS_V_2_18a is not set
-CT_BINUTILS_VERSION="2.24"
+CT_BINUTILS_VERSION="2.25"
+CT_BINUTILS_2_25_or_later=y
 CT_BINUTILS_2_24_or_later=y
 CT_BINUTILS_2_23_or_later=y
 CT_BINUTILS_2_22_or_later=y
@@ -272,22 +238,13 @@ CT_BINUTILS_2_19_or_later=y
 CT_BINUTILS_2_18_or_later=y
 CT_BINUTILS_HAS_HASH_STYLE=y
 CT_BINUTILS_HAS_GOLD=y
-CT_BINUTILS_GOLD_SUPPORTS_ARCH=y
 CT_BINUTILS_HAS_PLUGINS=y
 CT_BINUTILS_HAS_PKGVERSION_BUGURL=y
-CT_BINUTILS_FORCE_LD_BFD=y
-# CT_BINUTILS_LINKER_LD is not set
-CT_BINUTILS_LINKER_LD_GOLD=y
-# CT_BINUTILS_LINKER_GOLD_LD is not set
-CT_BINUTILS_GOLD_INSTALLED=y
-CT_BINUTILS_GOLD_THREADS=y
-CT_BINUTILS_LINKER_BOTH=y
-CT_BINUTILS_LINKERS_LIST="ld,gold"
-CT_BINUTILS_LD_WRAPPER=y
+CT_BINUTILS_LINKER_LD=y
+CT_BINUTILS_LINKERS_LIST="ld"
 CT_BINUTILS_LINKER_DEFAULT="bfd"
-CT_BINUTILS_PLUGINS=y
+# CT_BINUTILS_PLUGINS is not set
 CT_BINUTILS_EXTRA_CONFIG_ARRAY=""
-# CT_BINUTILS_FOR_TARGET is not set
 
 #
 # binutils other options
@@ -296,77 +253,56 @@ CT_BINUTILS_EXTRA_CONFIG_ARRAY=""
 #
 # C-library
 #
-CT_LIBC="glibc"
-CT_LIBC_VERSION="2.20"
-# CT_LIBC_eglibc is not set
-CT_LIBC_glibc=y
-# CT_LIBC_musl is not set
-# CT_LIBC_uClibc is not set
-CT_LIBC_eglibc_AVAILABLE=y
-CT_THREADS="nptl"
+CT_LIBC="newlib"
+CT_LIBC_VERSION="2.2.0"
+CT_LIBC_newlib=y
+# CT_LIBC_none is not set
 CT_LIBC_glibc_AVAILABLE=y
-# CT_LIBC_GLIBC_SHOW_LINARO is not set
-CT_LIBC_GLIBC_V_2_20=y
-# CT_LIBC_GLIBC_V_2_19 is not set
-# CT_LIBC_GLIBC_V_2_18 is not set
-# CT_LIBC_GLIBC_V_2_17 is not set
-# CT_LIBC_GLIBC_V_2_16_0 is not set
-# CT_LIBC_GLIBC_V_2_15 is not set
-# CT_LIBC_GLIBC_V_2_14_1 is not set
-# CT_LIBC_GLIBC_V_2_14 is not set
-# CT_LIBC_GLIBC_V_2_13 is not set
-# CT_LIBC_GLIBC_V_2_12_2 is not set
-# CT_LIBC_GLIBC_V_2_12_1 is not set
-# CT_LIBC_GLIBC_V_2_11_1 is not set
-# CT_LIBC_GLIBC_V_2_11 is not set
-# CT_LIBC_GLIBC_V_2_10_1 is not set
-# CT_LIBC_GLIBC_V_2_9 is not set
-# CT_LIBC_GLIBC_V_2_8 is not set
-CT_LIBC_GLIBC_2_20_or_later=y
+CT_THREADS="none"
 CT_LIBC_mingw_AVAILABLE=y
 CT_LIBC_musl_AVAILABLE=y
 CT_LIBC_newlib_AVAILABLE=y
+# CT_CC_NEWLIB_SHOW_LINARO is not set
+CT_LIBC_NEWLIB_V_2_2_0=y
+# CT_LIBC_NEWLIB_V_2_1_0 is not set
+# CT_LIBC_NEWLIB_V_2_0_0 is not set
+# CT_LIBC_NEWLIB_V_1_20_0 is not set
+# CT_LIBC_NEWLIB_V_1_19_0 is not set
+# CT_LIBC_NEWLIB_V_1_18_0 is not set
+# CT_LIBC_NEWLIB_V_1_17_0 is not set
+
+#
+# Architecture specific options
+#
 CT_LIBC_none_AVAILABLE=y
 CT_LIBC_uClibc_AVAILABLE=y
-CT_LIBC_SUPPORT_THREADS_ANY=y
-CT_LIBC_SUPPORT_THREADS_NATIVE=y
+CT_LIBC_SUPPORT_THREADS_NONE=y
 
 #
 # Common C library options
 #
-CT_THREADS_NATIVE=y
-CT_LIBC_XLDD=y
-# CT_LIBC_GLIBC_PORTS_EXTERNAL is not set
-CT_LIBC_glibc_familly=y
-CT_LIBC_GLIBC_EXTRA_CONFIG_ARRAY="--enable-obsolete-rpc"
-CT_LIBC_GLIBC_CONFIGPARMS=""
-CT_LIBC_GLIBC_EXTRA_CFLAGS=""
-CT_LIBC_EXTRA_CC_ARGS=""
-# CT_LIBC_DISABLE_VERSIONING is not set
-CT_LIBC_OLDEST_ABI=""
-CT_LIBC_GLIBC_FORCE_UNWIND=y
-CT_LIBC_ADDONS_LIST=""
-# CT_LIBC_LOCALES is not set
-CT_LIBC_GLIBC_KERNEL_VERSION_NONE=y
-# CT_LIBC_GLIBC_KERNEL_VERSION_AS_HEADERS is not set
-# CT_LIBC_GLIBC_KERNEL_VERSION_CHOSEN is not set
-CT_LIBC_GLIBC_MIN_KERNEL=""
+CT_THREADS_NONE=y
 
 #
-# glibc other options
+# newlib other options
 #
+# CT_LIBC_NEWLIB_IO_C99FMT is not set
+# CT_LIBC_NEWLIB_IO_LL is not set
+# CT_LIBC_NEWLIB_IO_FLOAT is not set
+# CT_LIBC_NEWLIB_DISABLE_SUPPLIED_SYSCALLS is not set
+CT_LIBC_NEWLIB_ENABLE_TARGET_OPTSPACE=y
+CT_LIBC_NEWLIB_EXTRA_CONFIG_ARRAY=""
 
 #
 # C compiler
 #
 CT_CC="gcc"
-CT_CC_VERSION="4.9.2"
-CT_CC_CORE_PASSES_NEEDED=y
-CT_CC_CORE_PASS_1_NEEDED=y
+CT_CC_VERSION="5.1.0"
 CT_CC_CORE_PASS_2_NEEDED=y
 CT_CC_gcc=y
 # CT_CC_GCC_SHOW_LINARO is not set
-CT_CC_V_4_9_2=y
+CT_CC_V_5_1=y
+# CT_CC_V_4_9_2 is not set
 # CT_CC_V_4_9_1 is not set
 # CT_CC_V_4_9_0 is not set
 # CT_CC_V_4_8_4 is not set
@@ -411,8 +347,9 @@ CT_CC_GCC_4_5_or_later=y
 CT_CC_GCC_4_6_or_later=y
 CT_CC_GCC_4_7_or_later=y
 CT_CC_GCC_4_8_or_later=y
-CT_CC_GCC_4_9=y
 CT_CC_GCC_4_9_or_later=y
+CT_CC_GCC_5_1=y
+CT_CC_GCC_5_1_or_later=y
 CT_CC_GCC_HAS_GRAPHITE=y
 CT_CC_GCC_USE_GRAPHITE=y
 CT_CC_GCC_HAS_LTO=y
@@ -420,8 +357,6 @@ CT_CC_GCC_USE_LTO=y
 CT_CC_GCC_HAS_PKGVERSION_BUGURL=y
 CT_CC_GCC_HAS_BUILD_ID=y
 CT_CC_GCC_HAS_LNK_HASH_STYLE=y
-CT_CC_GCC_ENABLE_PLUGINS=y
-CT_CC_GCC_GOLD=y
 CT_CC_GCC_USE_GMP_MPFR=y
 CT_CC_GCC_USE_MPC=y
 CT_CC_GCC_HAS_LIBQUADMATH=y
@@ -438,8 +373,7 @@ CT_CC_SUPPORT_GOLANG=y
 #
 # Additional supported languages:
 #
-CT_CC_LANG_CXX=y
-# CT_CC_LANG_JAVA is not set
+# CT_CC_LANG_CXX is not set
 
 #
 # gcc other options
@@ -462,21 +396,18 @@ CT_CC_GCC_ENABLE_TARGET_OPTSPACE=y
 # CT_CC_GCC_LIBGOMP is not set
 # CT_CC_GCC_LIBSSP is not set
 # CT_CC_GCC_LIBQUADMATH is not set
-# CT_CC_GCC_LIBSANITIZER is not set
 
 #
 # Misc. obscure options.
 #
-CT_CC_CXA_ATEXIT=y
 # CT_CC_GCC_DISABLE_PCH is not set
-CT_CC_GCC_SJLJ_EXCEPTIONS=m
 CT_CC_GCC_LDBL_128=m
 # CT_CC_GCC_BUILD_ID is not set
-# CT_CC_GCC_LNK_HASH_STYLE_DEFAULT is not set
+CT_CC_GCC_LNK_HASH_STYLE_DEFAULT=y
 # CT_CC_GCC_LNK_HASH_STYLE_SYSV is not set
 # CT_CC_GCC_LNK_HASH_STYLE_GNU is not set
-CT_CC_GCC_LNK_HASH_STYLE_BOTH=y
-CT_CC_GCC_LNK_HASH_STYLE="both"
+# CT_CC_GCC_LNK_HASH_STYLE_BOTH is not set
+CT_CC_GCC_LNK_HASH_STYLE=""
 CT_CC_GCC_DEC_FLOAT_AUTO=y
 # CT_CC_GCC_DEC_FLOAT_BID is not set
 # CT_CC_GCC_DEC_FLOAT_DPD is not set
@@ -498,16 +429,14 @@ CT_COMPLIBS_NEEDED=y
 CT_GMP_NEEDED=y
 CT_MPFR_NEEDED=y
 CT_ISL_NEEDED=y
-CT_CLOOG_NEEDED=y
 CT_MPC_NEEDED=y
 CT_COMPLIBS=y
 CT_GMP=y
 CT_MPFR=y
 CT_ISL=y
-CT_CLOOG=y
 CT_MPC=y
-# CT_GMP_V_6_0_0 is not set
-CT_GMP_V_5_1_3=y
+CT_GMP_V_6_0_0=y
+# CT_GMP_V_5_1_3 is not set
 # CT_GMP_V_5_1_1 is not set
 # CT_GMP_V_5_0_2 is not set
 # CT_GMP_V_5_0_1 is not set
@@ -515,7 +444,7 @@ CT_GMP_V_5_1_3=y
 # CT_GMP_V_4_3_1 is not set
 # CT_GMP_V_4_3_0 is not set
 CT_GMP_5_0_2_or_later=y
-CT_GMP_VERSION="5.1.3"
+CT_GMP_VERSION="6.0.0a"
 CT_MPFR_V_3_1_2=y
 # CT_MPFR_V_3_1_0 is not set
 # CT_MPFR_V_3_0_1 is not set
@@ -524,13 +453,9 @@ CT_MPFR_V_3_1_2=y
 # CT_MPFR_V_2_4_1 is not set
 # CT_MPFR_V_2_4_0 is not set
 CT_MPFR_VERSION="3.1.2"
-CT_ISL_V_0_12_2=y
-# CT_ISL_V_0_11_1 is not set
-CT_ISL_VERSION="0.12.2"
-CT_CLOOG_V_0_18_1=y
-# CT_CLOOG_V_0_18_0 is not set
-CT_CLOOG_VERSION="0.18.1"
-CT_CLOOG_0_18_or_later=y
+CT_ISL_V_0_14=y
+# CT_ISL_V_0_12_2 is not set
+CT_ISL_VERSION="0.14"
 CT_MPC_V_1_0_2=y
 # CT_MPC_V_1_0_1 is not set
 # CT_MPC_V_1_0 is not set

--- a/configs/mistify-tc.config
+++ b/configs/mistify-tc.config
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
 # crosstool-NG 1.21.0 Configuration
-# Thu Jun  4 12:41:22 2015
+# Thu Jun  4 12:45:00 2015
 #
 CT_CONFIGURE_has_make381=y
 CT_CONFIGURE_has_xz=y
@@ -297,12 +297,12 @@ CT_LIBC_NEWLIB_EXTRA_CONFIG_ARRAY=""
 # C compiler
 #
 CT_CC="gcc"
-CT_CC_VERSION="5.1.0"
+CT_CC_VERSION="4.9.2"
 CT_CC_CORE_PASS_2_NEEDED=y
 CT_CC_gcc=y
 # CT_CC_GCC_SHOW_LINARO is not set
-CT_CC_V_5_1=y
-# CT_CC_V_4_9_2 is not set
+# CT_CC_V_5_1 is not set
+CT_CC_V_4_9_2=y
 # CT_CC_V_4_9_1 is not set
 # CT_CC_V_4_9_0 is not set
 # CT_CC_V_4_8_4 is not set
@@ -347,9 +347,8 @@ CT_CC_GCC_4_5_or_later=y
 CT_CC_GCC_4_6_or_later=y
 CT_CC_GCC_4_7_or_later=y
 CT_CC_GCC_4_8_or_later=y
+CT_CC_GCC_4_9=y
 CT_CC_GCC_4_9_or_later=y
-CT_CC_GCC_5_1=y
-CT_CC_GCC_5_1_or_later=y
 CT_CC_GCC_HAS_GRAPHITE=y
 CT_CC_GCC_USE_GRAPHITE=y
 CT_CC_GCC_HAS_LTO=y
@@ -429,11 +428,13 @@ CT_COMPLIBS_NEEDED=y
 CT_GMP_NEEDED=y
 CT_MPFR_NEEDED=y
 CT_ISL_NEEDED=y
+CT_CLOOG_NEEDED=y
 CT_MPC_NEEDED=y
 CT_COMPLIBS=y
 CT_GMP=y
 CT_MPFR=y
 CT_ISL=y
+CT_CLOOG=y
 CT_MPC=y
 CT_GMP_V_6_0_0=y
 # CT_GMP_V_5_1_3 is not set
@@ -455,7 +456,12 @@ CT_MPFR_V_3_1_2=y
 CT_MPFR_VERSION="3.1.2"
 CT_ISL_V_0_14=y
 # CT_ISL_V_0_12_2 is not set
+# CT_ISL_V_0_11_1 is not set
 CT_ISL_VERSION="0.14"
+CT_CLOOG_V_0_18_1=y
+# CT_CLOOG_V_0_18_0 is not set
+CT_CLOOG_VERSION="0.18.1"
+CT_CLOOG_0_18_or_later=y
 CT_MPC_V_1_0_2=y
 # CT_MPC_V_1_0_1 is not set
 # CT_MPC_V_1_0 is not set

--- a/configs/mistify-tc.config
+++ b/configs/mistify-tc.config
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
 # crosstool-NG 1.21.0 Configuration
-# Thu Jun  4 12:45:00 2015
+# Thu Jun  4 18:05:01 2015
 #
 CT_CONFIGURE_has_make381=y
 CT_CONFIGURE_has_xz=y
@@ -22,13 +22,14 @@ CT_MODULES=y
 #
 # Paths
 #
-CT_LOCAL_TARBALLS_DIR=""
+CT_LOCAL_TARBALLS_DIR="${TC_LOCAL_TARBALLS_DIR}"
+CT_SAVE_TARBALLS=y
 CT_WORK_DIR="${CT_TOP_DIR}/.build"
-CT_PREFIX_DIR="${HOME}/x-tools/${CT_TARGET}"
+CT_PREFIX_DIR="${TC_PREFIX_DIR}"
 CT_INSTALL_DIR="${CT_PREFIX_DIR}"
 CT_RM_RF_PREFIX_DIR=y
 CT_REMOVE_DOCS=y
-CT_INSTALL_DIR_RO=y
+# CT_INSTALL_DIR_RO is not set
 CT_STRIP_ALL_TOOLCHAIN_EXECUTABLES=y
 
 #
@@ -76,31 +77,35 @@ CT_CONFIG_SHELL="${bash}"
 #
 # CT_LOG_ERROR is not set
 # CT_LOG_WARN is not set
-CT_LOG_INFO=y
-# CT_LOG_EXTRA is not set
+# CT_LOG_INFO is not set
+CT_LOG_EXTRA=y
 # CT_LOG_ALL is not set
 # CT_LOG_DEBUG is not set
-CT_LOG_LEVEL_MAX="INFO"
+CT_LOG_LEVEL_MAX="EXTRA"
 # CT_LOG_SEE_TOOLS_WARN is not set
-CT_LOG_PROGRESS_BAR=y
+# CT_LOG_PROGRESS_BAR is not set
 CT_LOG_TO_FILE=y
 CT_LOG_FILE_COMPRESS=y
 
 #
 # Target options
 #
-CT_ARCH="alpha"
+CT_ARCH="x86"
 CT_ARCH_SUPPORTS_32=y
+CT_ARCH_SUPPORTS_64=y
+CT_ARCH_SUPPORTS_WITH_ARCH=y
 CT_ARCH_SUPPORTS_WITH_CPU=y
 CT_ARCH_SUPPORTS_WITH_TUNE=y
 CT_ARCH_DEFAULT_32=y
+CT_ARCH_ARCH=""
 CT_ARCH_CPU=""
 CT_ARCH_TUNE=""
-CT_ARCH_32=y
-CT_ARCH_BITNESS=32
+# CT_ARCH_32 is not set
+CT_ARCH_64=y
+CT_ARCH_BITNESS=64
 CT_TARGET_CFLAGS=""
 CT_TARGET_LDFLAGS=""
-CT_ARCH_alpha=y
+# CT_ARCH_alpha is not set
 # CT_ARCH_arm is not set
 # CT_ARCH_avr32 is not set
 # CT_ARCH_blackfin is not set
@@ -111,7 +116,7 @@ CT_ARCH_alpha=y
 # CT_ARCH_s390 is not set
 # CT_ARCH_sh is not set
 # CT_ARCH_sparc is not set
-# CT_ARCH_x86 is not set
+CT_ARCH_x86=y
 CT_ARCH_alpha_AVAILABLE=y
 CT_ARCH_arm_AVAILABLE=y
 CT_ARCH_avr32_AVAILABLE=y
@@ -137,17 +142,6 @@ CT_ARCH_USE_MMU=y
 # Target optimisations
 #
 CT_ARCH_FLOAT=""
-
-#
-# alpha other options
-#
-CT_ARCH_ALPHA_EV4=y
-# CT_ARCH_ALPHA_EV45 is not set
-# CT_ARCH_ALPHA_EV5 is not set
-# CT_ARCH_ALPHA_EV56 is not set
-# CT_ARCH_ALPHA_EV6 is not set
-# CT_ARCH_ALPHA_EV67 is not set
-CT_ARCH_ALPHA_VARIANT="ev4"
 
 #
 # Toolchain options
@@ -194,17 +188,39 @@ CT_BUILD_SUFFIX=""
 #
 # Operating System
 #
-CT_BARE_METAL=y
-CT_KERNEL="bare-metal"
-CT_KERNEL_bare_metal=y
-# CT_KERNEL_linux is not set
+CT_KERNEL_SUPPORTS_SHARED_LIBS=y
+CT_KERNEL="linux"
+CT_KERNEL_VERSION="3.18.14"
+# CT_KERNEL_bare_metal is not set
+CT_KERNEL_linux=y
+# CT_KERNEL_windows is not set
 CT_KERNEL_bare_metal_AVAILABLE=y
 CT_KERNEL_linux_AVAILABLE=y
+# CT_KERNEL_V_4_0 is not set
+# CT_KERNEL_V_3_19 is not set
+CT_KERNEL_V_3_18=y
+# CT_KERNEL_V_3_14 is not set
+# CT_KERNEL_V_3_12 is not set
+# CT_KERNEL_V_3_10 is not set
+# CT_KERNEL_V_3_4 is not set
+# CT_KERNEL_V_3_2 is not set
+# CT_KERNEL_V_2_6_32 is not set
+# CT_KERNEL_LINUX_CUSTOM is not set
 CT_KERNEL_windows_AVAILABLE=y
 
 #
 # Common kernel options
 #
+CT_SHARED_LIBS=y
+
+#
+# linux other options
+#
+CT_KERNEL_LINUX_VERBOSITY_0=y
+# CT_KERNEL_LINUX_VERBOSITY_1 is not set
+# CT_KERNEL_LINUX_VERBOSITY_2 is not set
+CT_KERNEL_LINUX_VERBOSE_LEVEL=0
+CT_KERNEL_LINUX_INSTALL_CHECK=y
 
 #
 # Binary utilities
@@ -238,13 +254,22 @@ CT_BINUTILS_2_19_or_later=y
 CT_BINUTILS_2_18_or_later=y
 CT_BINUTILS_HAS_HASH_STYLE=y
 CT_BINUTILS_HAS_GOLD=y
+CT_BINUTILS_GOLD_SUPPORTS_ARCH=y
 CT_BINUTILS_HAS_PLUGINS=y
 CT_BINUTILS_HAS_PKGVERSION_BUGURL=y
-CT_BINUTILS_LINKER_LD=y
-CT_BINUTILS_LINKERS_LIST="ld"
+CT_BINUTILS_FORCE_LD_BFD=y
+# CT_BINUTILS_LINKER_LD is not set
+CT_BINUTILS_LINKER_LD_GOLD=y
+# CT_BINUTILS_LINKER_GOLD_LD is not set
+CT_BINUTILS_GOLD_INSTALLED=y
+CT_BINUTILS_GOLD_THREADS=y
+CT_BINUTILS_LINKER_BOTH=y
+CT_BINUTILS_LINKERS_LIST="ld,gold"
+CT_BINUTILS_LD_WRAPPER=y
 CT_BINUTILS_LINKER_DEFAULT="bfd"
-# CT_BINUTILS_PLUGINS is not set
+CT_BINUTILS_PLUGINS=y
 CT_BINUTILS_EXTRA_CONFIG_ARRAY=""
+# CT_BINUTILS_FOR_TARGET is not set
 
 #
 # binutils other options
@@ -253,51 +278,72 @@ CT_BINUTILS_EXTRA_CONFIG_ARRAY=""
 #
 # C-library
 #
-CT_LIBC="newlib"
-CT_LIBC_VERSION="2.2.0"
-CT_LIBC_newlib=y
-# CT_LIBC_none is not set
+CT_LIBC="glibc"
+CT_LIBC_VERSION="2.21"
+CT_LIBC_glibc=y
+# CT_LIBC_musl is not set
+# CT_LIBC_uClibc is not set
 CT_LIBC_glibc_AVAILABLE=y
-CT_THREADS="none"
+CT_THREADS="nptl"
+# CT_CC_GLIBC_SHOW_LINARO is not set
+CT_LIBC_GLIBC_V_2_21=y
+# CT_LIBC_GLIBC_V_2_20 is not set
+# CT_LIBC_GLIBC_V_2_19 is not set
+# CT_LIBC_GLIBC_V_2_18 is not set
+# CT_LIBC_GLIBC_V_2_17 is not set
+# CT_LIBC_GLIBC_V_2_16_0 is not set
+# CT_LIBC_GLIBC_V_2_15 is not set
+# CT_LIBC_GLIBC_V_2_14_1 is not set
+# CT_LIBC_GLIBC_V_2_14 is not set
+# CT_LIBC_GLIBC_V_2_13 is not set
+# CT_LIBC_GLIBC_V_2_12_2 is not set
+# CT_LIBC_GLIBC_V_2_12_1 is not set
+# CT_LIBC_GLIBC_V_2_11_1 is not set
+# CT_LIBC_GLIBC_V_2_11 is not set
+# CT_LIBC_GLIBC_V_2_10_1 is not set
+# CT_LIBC_GLIBC_V_2_9 is not set
+# CT_LIBC_GLIBC_V_2_8 is not set
+CT_LIBC_GLIBC_2_20_or_later=y
 CT_LIBC_mingw_AVAILABLE=y
 CT_LIBC_musl_AVAILABLE=y
 CT_LIBC_newlib_AVAILABLE=y
-# CT_CC_NEWLIB_SHOW_LINARO is not set
-CT_LIBC_NEWLIB_V_2_2_0=y
-# CT_LIBC_NEWLIB_V_2_1_0 is not set
-# CT_LIBC_NEWLIB_V_2_0_0 is not set
-# CT_LIBC_NEWLIB_V_1_20_0 is not set
-# CT_LIBC_NEWLIB_V_1_19_0 is not set
-# CT_LIBC_NEWLIB_V_1_18_0 is not set
-# CT_LIBC_NEWLIB_V_1_17_0 is not set
-
-#
-# Architecture specific options
-#
 CT_LIBC_none_AVAILABLE=y
 CT_LIBC_uClibc_AVAILABLE=y
-CT_LIBC_SUPPORT_THREADS_NONE=y
+CT_LIBC_SUPPORT_THREADS_ANY=y
+CT_LIBC_SUPPORT_THREADS_NATIVE=y
 
 #
 # Common C library options
 #
-CT_THREADS_NONE=y
+CT_THREADS_NATIVE=y
+CT_LIBC_XLDD=y
 
 #
-# newlib other options
+# glibc other options
 #
-# CT_LIBC_NEWLIB_IO_C99FMT is not set
-# CT_LIBC_NEWLIB_IO_LL is not set
-# CT_LIBC_NEWLIB_IO_FLOAT is not set
-# CT_LIBC_NEWLIB_DISABLE_SUPPLIED_SYSCALLS is not set
-CT_LIBC_NEWLIB_ENABLE_TARGET_OPTSPACE=y
-CT_LIBC_NEWLIB_EXTRA_CONFIG_ARRAY=""
+# CT_LIBC_GLIBC_PORTS_EXTERNAL is not set
+CT_LIBC_glibc_familly=y
+CT_LIBC_GLIBC_EXTRA_CONFIG_ARRAY="--enable-obsolete-rpc"
+CT_LIBC_GLIBC_CONFIGPARMS=""
+CT_LIBC_GLIBC_EXTRA_CFLAGS=""
+CT_LIBC_EXTRA_CC_ARGS=""
+# CT_LIBC_DISABLE_VERSIONING is not set
+CT_LIBC_OLDEST_ABI=""
+CT_LIBC_GLIBC_FORCE_UNWIND=y
+CT_LIBC_ADDONS_LIST=""
+# CT_LIBC_LOCALES is not set
+# CT_LIBC_GLIBC_KERNEL_VERSION_NONE is not set
+CT_LIBC_GLIBC_KERNEL_VERSION_AS_HEADERS=y
+# CT_LIBC_GLIBC_KERNEL_VERSION_CHOSEN is not set
+CT_LIBC_GLIBC_MIN_KERNEL="3.18.14"
 
 #
 # C compiler
 #
 CT_CC="gcc"
 CT_CC_VERSION="4.9.2"
+CT_CC_CORE_PASSES_NEEDED=y
+CT_CC_CORE_PASS_1_NEEDED=y
 CT_CC_CORE_PASS_2_NEEDED=y
 CT_CC_gcc=y
 # CT_CC_GCC_SHOW_LINARO is not set
@@ -356,6 +402,8 @@ CT_CC_GCC_USE_LTO=y
 CT_CC_GCC_HAS_PKGVERSION_BUGURL=y
 CT_CC_GCC_HAS_BUILD_ID=y
 CT_CC_GCC_HAS_LNK_HASH_STYLE=y
+CT_CC_GCC_ENABLE_PLUGINS=y
+CT_CC_GCC_GOLD=y
 CT_CC_GCC_USE_GMP_MPFR=y
 CT_CC_GCC_USE_MPC=y
 CT_CC_GCC_HAS_LIBQUADMATH=y
@@ -372,7 +420,8 @@ CT_CC_SUPPORT_GOLANG=y
 #
 # Additional supported languages:
 #
-# CT_CC_LANG_CXX is not set
+CT_CC_LANG_CXX=y
+# CT_CC_LANG_JAVA is not set
 
 #
 # gcc other options
@@ -394,12 +443,15 @@ CT_CC_GCC_ENABLE_TARGET_OPTSPACE=y
 # CT_CC_GCC_LIBMUDFLAP is not set
 # CT_CC_GCC_LIBGOMP is not set
 # CT_CC_GCC_LIBSSP is not set
-# CT_CC_GCC_LIBQUADMATH is not set
+CT_CC_GCC_LIBQUADMATH=y
+CT_CC_GCC_LIBSANITIZER=y
 
 #
 # Misc. obscure options.
 #
+CT_CC_CXA_ATEXIT=y
 # CT_CC_GCC_DISABLE_PCH is not set
+CT_CC_GCC_SJLJ_EXCEPTIONS=m
 CT_CC_GCC_LDBL_128=m
 # CT_CC_GCC_BUILD_ID is not set
 CT_CC_GCC_LNK_HASH_STYLE_DEFAULT=y
@@ -454,10 +506,10 @@ CT_MPFR_V_3_1_2=y
 # CT_MPFR_V_2_4_1 is not set
 # CT_MPFR_V_2_4_0 is not set
 CT_MPFR_VERSION="3.1.2"
-CT_ISL_V_0_14=y
-# CT_ISL_V_0_12_2 is not set
+# CT_ISL_V_0_14 is not set
+CT_ISL_V_0_12_2=y
 # CT_ISL_V_0_11_1 is not set
-CT_ISL_VERSION="0.14"
+CT_ISL_VERSION="0.12.2"
 CT_CLOOG_V_0_18_1=y
 # CT_CLOOG_V_0_18_0 is not set
 CT_CLOOG_VERSION="0.18.1"

--- a/jenkins
+++ b/jenkins
@@ -7,6 +7,7 @@ source scripts/mistify-functions.sh
 
 jenkinsdefault=$(get_build_default jenkins http://mistify-dev-2.office.omniti.com:8081)
 jenkinsjobdefault=$(get_build_default jenkinsjob MistifyOS-remote)
+jenkinsmistifybranchdefault=$(get_build_default jenkinsmistifybranch $mistifybranch)
 
 usage () {
     cat << EOF
@@ -24,11 +25,15 @@ Usage: $0 [options] [-- joboptions]
         The job to execute. This must match a name in the Jenkins job list. This
         is saved in the file: $statedir/jenkinsjob
         [job=$jenkinsjobdefault]
+    --mistifybranch <branch>
+        The Mistify-OS branch or tag to checkout for the build.
+        This is saved in the file: $statedir/jenkinsmistifybranch
+        [mistifybranch=$jenkinsmistifybranchdefault]
     -- <joboptions>
         Anything following the "--" is passed directly to the Jenkins server.
         This can be additional options to pass to a script or a complete
         command line depending upon how the job is configured on the server. The
-        job needs to be configured to accept a parameter named "options".
+        job needs to be configured to accept a parameter named "mistify_job_options".
 
     Parameters passed to the Jenkins server:
         [branch=$mistifybranch]
@@ -64,7 +69,7 @@ while [ $# -ge 1 ]; do
     case "$1" in
 	--)
 	    shift
-	    options=$*
+	    mistify_job_options=$*
 	    break
 	    ;;
 	--jenkins)
@@ -73,6 +78,10 @@ while [ $# -ge 1 ]; do
 	    ;;
 	--job)
 	    jenkinsjob=$2
+	    shift
+	    ;;
+	--mistifybranch)
+	    jenkinsmistifybranch=$2
 	    shift
 	    ;;
 	--dryrun)
@@ -100,24 +109,29 @@ if [ -z "$jenkinsjob" ]; then
     jenkinsjob=$jenkinsjobdefault
 fi
 
-if [ -n "$options" ]; then
-  message "Options are: $options"
-  params="&options="
-  params+=`echo $options | sed 's/ /%20/g'`
+if [ -z "$jenkinsmistifybranch" ]; then
+    jenkinsmistifybranch=$jenkinsmistifybranchdefault
+fi
+
+if [ -n "$mistify_job_options" ]; then
+  message "Options are: $mistify_job_options"
+  params="&mistify_job_options="
+  params+=`echo $mistify_job_options | sed 's/ /%20/g'`
   message "Adding Jenkins parameters: $params"
 fi
 
-jenkinscommand="wget -O /dev/null $jenkins/job/$jenkinsjob/buildWithParameters?token=buildmistify&branch=$mistifybranch$params"
+jenkinscommand="wget -O /dev/null $jenkins/job/$jenkinsjob/buildWithParameters?token=buildmistify&mistify_branch=$jenkinsmistifybranch$params"
 
 if [ -n "$dryrun" ]; then
   message "Just a test run -- not building."
 else
   set_build_default jenkins $jenkins
   set_build_default jenkinsjob $jenkinsjob
+  set_build_default jenkinsmistifybranch $jenkinsmistifybranch
 fi
 
 message "Triggering a remote build on Jenkins server: $jenkins"
-message "The branch is: $mistifybranch"
+message "The branch is: $jenkinsmistifybranch"
 $dryrun $jenkinscommand
 if [ $? -gt 0 ]; then
   error The Jenkins server is not running at the URL or did not accept the job.

--- a/scripts/install-go.sh
+++ b/scripts/install-go.sh
@@ -3,6 +3,9 @@
 # NOTE: The go repo is mirrored on github. The install instructions point to
 # the googlesource repo so that URL is the default for this script. Of course
 # it can be overridden using the --gouri command line option.
+# NOTE: This relies upon the toolchainversion variable from the install-toolchain
+# script. This is because th path to the toolchain is embedded and different
+# versions of the toolchain can be selected.
 #-
 gouridefault=git@github.com:golang/go.git
 godirdefault=$PWD/go
@@ -58,10 +61,13 @@ install-go () {
     message "The go branch or tag is: $gotag"
     echo $gotag >$statedir/gotag
 
-    GOROOT=$godir/$gotag/go
+    golabel=$gotag-$toolchainversion
+    verbose The Go label is: $golabel
+
+    GOROOT=$godir/$golabel/go
     verbose "The go binaries are located at: $GOROOT"
 
-    if [ -f $godir/.$gotag-built ]; then
+    if [ -f $godir/.$golabel-built ]; then
 	message "Using go version $gotag."
 	return
     fi
@@ -72,8 +78,8 @@ install-go () {
 	message "Just a test run -- not building the toolchain."
 	verbose "./all.bash"
     else
-	run mkdir -p $godir/$gotag
-	cd $godir/$gotag
+	run mkdir -p $godir/$golabel
+	cd $godir/$golabel
 	verbose "Working directory is: $PWD"
 	if [ ! -d go ]; then
 	    run git clone $gouri
@@ -97,6 +103,6 @@ install-go () {
 	unset CXX_FOR_TARGET
 	unset CGO_ENABLED
 
-	touch $godir/.$gotag-built
+	touch $godir/.$golabel-built
     fi
 }

--- a/scripts/install-toolchain.sh
+++ b/scripts/install-toolchain.sh
@@ -27,6 +27,8 @@ build-toolchain () {
     mkdir -p $TC_LOCAL_TARBALLS_DIR
     cd $toolchaindir
     time $ctng build 2>&1 | tee $logdir/tc-`date +%y%m%d%H%M%S`.log
+    tail build.log | grep "Build completed"
+
     if [ $? -gt 0 ]; then
 	die "The toolchain build failed."
     fi

--- a/scripts/install-toolchain.sh
+++ b/scripts/install-toolchain.sh
@@ -28,8 +28,7 @@ build-toolchain () {
     cd $toolchaindir
     time $ctng build 2>&1 | tee $logdir/tc-`date +%y%m%d%H%M%S`.log
     if [ $? -gt 0 ]; then
-	error "The toolchain build failed."
-	exit 1
+	die "The toolchain build failed."
     fi
 }
 
@@ -86,8 +85,7 @@ install-toolchain () {
 	# git again to update just in case.
 	#-
 	if [ $? -gt 0 ]; then
-	    error "Cloning the toolchain encountered an error."
-	    exit 1
+	    die "Cloning the toolchain encountered an error."
 	fi
     fi
     cd $toolchaindir
@@ -98,8 +96,7 @@ install-toolchain () {
 
     run git checkout $toolchainversion
     if [ $? -ne 0 ]; then
-	error "Attempted to checkout the toolchain build tool using an invalid ID: $toolchainversion"
-	exit 1
+	die "Attempted to checkout the toolchain build tool using an invalid ID: $toolchainversion"
     fi
     #+
     # If on a branch then pull the latest changes.
@@ -155,8 +152,7 @@ install-toolchain () {
 	    ls -l $tcc $tcconfig
 	    cp $tcc $tcconfig
 	    if [ $? -gt 0 ]; then
-		error "Failed to save $tcconfig"
-		exit 1
+		die "Failed to save $tcconfig"
 	    else
 		rm $toolchainbuilt
 		message "Toolchain config file has been saved to: $tcconfig"


### PR DESCRIPTION
This version has several changes:
- The crosstool-ng version has been locked to the latest release -- crosstool-ng-1.21.0. The crosstool master branch is in a state of change which has resulted in config file variable name changes which in turn breaks a build using our config file.
- The toolchain config file (configs/mistify-tc.config) has been updated to match the crosstool-ng-1.21.0 release.
- Supporting library versions (e.g. glibc) have been updated.
- The toolchain install script has been modified to collapse the tag/branch logic into a simpler version logic. This now supports tags, branches and even commit IDs using the same command line option. The buildmistify script has been modified to support the revised toolchain optons.
- The toolchain and Go builds now use the toolchain version to create unique builds based upon the toolchain version (tag, branch or commit ID). It was discovered during this effort that Go uses the version of `ld` included in the toolchain used to build Go. The toolchain version is used to name directories where the toolchain and Go builds occur.
- The toolchain install script has been updated to use the get_build_default and set_build_default functions provided in mistify-functions.sh.
- The logic to stop when a new toolchain configuration has been removed because it was stopping an automated build after building the toolchains making it necessary to restart the build in order to have a complete build. For jenkins this was causing some misleading green indications.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-os/108)
<!-- Reviewable:end -->
