### PR TITLE
Gopackage template makefile

### DIFF
--- a/package/mistify/gopackage/Makefile.template
+++ b/package/mistify/gopackage/Makefile.template
@@ -1,0 +1,31 @@
+###################################################
+# Sample GO package make file.
+# This is a template make file which can be used to compile GO components.
+# The pattern "_PACKAGE_" is replaced with the target name (GOPACKAGENAME).
+###################################################
+
+#+
+# Useful environment variables which are passed from the buildgopackage script.
+#
+# GOPACKAGEDIR	Where the package source code and makefile is located.
+# GOPACKAGENAME	The name to associate with the package. This is used to name
+#		the build directory among other things. This also allows
+#		different agents to be built using this one package.
+# DRYRUN	Most often used to echo commands rather than actually execute
+#		them.
+# DESTDIR	Is ignored since this generic template can be used to build a
+#		GO package for variety of purposes.
+#-
+
+PREFIX := /opt/mistify
+SBIN_DIR=$(PREFIX)/sbin
+
+_PACKAGE_: main.go
+	$(DRYRUN) go get && \
+	$(DRYRUN) go build
+
+clean:
+	$(DRYRUN) go clean
+
+install: _PACKAGE_
+	@echo The actual install must be done manually.

--- a/package/mistify/gopackage/gopackage.mk
+++ b/package/mistify/gopackage/gopackage.mk
@@ -30,7 +30,12 @@ define GOPACKAGE_BUILD_CMDS
 	# GO apparently wants the install path to be independent of the
 	# build path. Use a temporary directory to do the build.
 	mkdir -p $(GOPATH)/src/github.com/mistifyio/$(GOPACKAGENAME)
-	rsync -av --delete-after --exclude=.git --exclude-from=$(@D)/.gitignore \
+	if [ ! -f $(@D)/Makefile ]; then \
+		sed s/_PACKAGE_/$(GOPACKAGENAME)/g \
+		<$(BR2_EXTERNAL)/package/mistify/gopackage/Makefile.template \
+		>$(@D)/Makefile; \
+	fi
+	rsync -av --delete-after --exclude=.git  \
 		$(@D)/ $(GOPATH)/src/github.com/mistifyio/$(GOPACKAGENAME)/
 	GOROOT=$(GOROOT) \
 		PATH=$(GOROOT)/bin:$(PATH) \

--- a/package/mistify/gopackage/gopackage.mk
+++ b/package/mistify/gopackage/gopackage.mk
@@ -35,7 +35,7 @@ define GOPACKAGE_BUILD_CMDS
 		<$(BR2_EXTERNAL)/package/mistify/gopackage/Makefile.template \
 		>$(@D)/Makefile; \
 	fi
-	rsync -av --delete-after --exclude=.git  \
+	rsync -av --delete-after --exclude=.git --exclude-from=$(@D)/.gitignore \
 		$(@D)/ $(GOPATH)/src/github.com/mistifyio/$(GOPACKAGENAME)/
 	GOROOT=$(GOROOT) \
 		PATH=$(GOROOT)/bin:$(PATH) \


### PR DESCRIPTION
This adds a generic make file template which is used to generate a makefile for a go package which doesn't include a makefile of its own. e.g. This enables building lochness/cmd/[hv,guest] using the buildgopackage script.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-os/115)
<!-- Reviewable:end -->
