### PR TITLE
zfs: Add udev rule for /dev/zfs permissions

### DIFF
--- a/package/mistify/zfs/91-zfs-permissions.rules
+++ b/package/mistify/zfs/91-zfs-permissions.rules
@@ -1,0 +1,2 @@
+# Allow users to interact with ZFS (note zfsonlinux/zfs#362)
+ACTION=="add", KERNEL=="zfs", MODE="0666"

--- a/package/mistify/zfs/zfs.mk
+++ b/package/mistify/zfs/zfs.mk
@@ -41,7 +41,14 @@ define ZFS_INSTALL_INIT_SYSTEMD
 		$(TARGET_DIR)/etc/systemd/system/multi-user.target.wants/zfs.target
 endef
 
+define ZFS_INSTALL_UDEV_RULES
+	$(INSTALL) -m 644 -D \
+		$(BR2_EXTERNAL)/package/mistify/zfs/91-zfs-permissions.rules \
+		$(TARGET_DIR)/lib/udev/rules.d/91-zfs-permissions.rules
+endef
+
 ZFS_POST_INSTALL_TARGET_HOOKS += ZFS_REMOVE_INIT_SCRIPT
+ZFS_POST_INSTALL_TARGET_HOOKS += ZFS_INSTALL_UDEV_RULES
 
 ZFS_CONF_OPTS = \
     --prefix=/usr \


### PR DESCRIPTION
This is necessary for container access to /dev/zfs. Without proper delegation support, this still leaks some privileged ZFS ops (though there are plenty of other security issues with our container impl right now).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-os/121)
<!-- Reviewable:end -->
