### PR TITLE
MIST-524 Bump etcd version to v2.1.1

### DIFF
--- a/board/mistify/rootfs_overlay/root/cluster-init
+++ b/board/mistify/rootfs_overlay/root/cluster-init
@@ -74,6 +74,7 @@ echo "$LINENO: done"
 echo "$LINENO: setting up etcd to listen on external interfaces"
 cat > /etc/sysconfig/etcd <<EOF
 ETCD_LISTEN_CLIENT_URLS=http://$ip:2379,http://$ip:4001,http://localhost:2379,http://localhost:4001
+ETCD_ADVERTISE_CLIENT_URLS=http://localhost:2379,http://localhost:4001
 EOF
 systemctl restart etcd
 sleep .100

--- a/package/mistify/etcd/etcd.mk
+++ b/package/mistify/etcd/etcd.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-ETCD_VERSION = v2.0.4
+ETCD_VERSION = v2.1.1
 ETCD_SITE    = https://github.com/coreos/etcd/archive/
 ETCD_SOURCE = $(ETCD_VERSION).tar.gz
 ETCD_LICENSE = Apache
@@ -26,8 +26,6 @@ define ETCD_INSTALL_TARGET_CMDS
 		$(TARGET_DIR)/usr/sbin/etcd
 	$(INSTALL) -m 755 -D $(ETCD_DIR)/bin/etcdctl \
 		$(TARGET_DIR)/usr/bin/etcdctl
-	$(INSTALL) -m 755 -D $(ETCD_DIR)/bin/etcd-migrate \
-		$(TARGET_DIR)/usr/bin/etcd-migrate
 endef
 
 define ETCD_USERS


### PR DESCRIPTION
With this version, if ETCD_LISTEN_CLIENT_URLS is explicitly set, then
ETCD_ADVERTISE_CLIENT_URLS is required explicitly for etcd to start.
Additionally, as of etcd commit
https://github.com/coreos/etcd/commit/a9157ce6d33931ef4b06c3538c52796d539a495b
etcd is not automatically building etcd-migrate. We don't use it, so
don't attempt to install it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-os/132)
<!-- Reviewable:end -->
