### PR TITLE
MIST-286 Initialize the ovs bridge mac file

### DIFF
--- a/board/mistify/rootfs_overlay/etc/pre-init.d/net-init.sh
+++ b/board/mistify/rootfs_overlay/etc/pre-init.d/net-init.sh
@@ -136,6 +136,8 @@ case "$1" in
     'start')
         # Initialize our own interface state file
         cp /dev/null $MISTIFY_IFSTATE
+        # Initialize the ovs bridge mac file if necessary
+        touch $MISTIFY_MAC
 
         parse_boot_args
 


### PR DESCRIPTION
Touch the file so it exists for services that are looking for it even if DHCP or manual IP configuration fails.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-os/135)
<!-- Reviewable:end -->
