### PR TITLE
MIST-286 Make ovsbridge EnvironmentFile optional

### DIFF
--- a/board/mistify/rootfs_overlay/etc/pre-init.d/net-init.sh
+++ b/board/mistify/rootfs_overlay/etc/pre-init.d/net-init.sh
@@ -136,8 +136,6 @@ case "$1" in
     'start')
         # Initialize our own interface state file
         cp /dev/null $MISTIFY_IFSTATE
-        # Initialize the ovs bridge mac file if necessary
-        touch $MISTIFY_MAC
 
         parse_boot_args
 

--- a/package/mistify/openvswitch/ovsbridge.service
+++ b/package/mistify/openvswitch/ovsbridge.service
@@ -5,7 +5,7 @@ Wants=openvswitch.service
 
 [Service]
 Type=oneshot
-EnvironmentFile=/etc/sysconfig/ovsbridge
+EnvironmentFile=-/etc/sysconfig/ovsbridge
 ExecStart=/usr/sbin/ovsbridge
 
 [Install]


### PR DESCRIPTION
No need to depend on net-init to create the file to have the service run
successfully

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-os/136)
<!-- Reviewable:end -->
