### PR TITLE
MIST-286 No need to wait on curling node /v2/keys

### DIFF
--- a/board/mistify/rootfs_overlay/root/cluster-init
+++ b/board/mistify/rootfs_overlay/root/cluster-init
@@ -239,7 +239,6 @@ function add_hypervisor() {
     log "done"
 
     log "waiting for hypervisor. please start node$index"
-    do_until 5 curl --silent http://${ips[$index]}:4001/v2/keys
     do_until 5 etcdctl cluster-health
     log "done"
 


### PR DESCRIPTION
The etcdctl cluster-health exits with an error status code if the
cluster is unhealthy, so we can just wait for that. The extra curl
directly to the node etcd is redundant here and causes delays.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-os/138)
<!-- Reviewable:end -->
