### PR TITLE
MIST-286 Correct etcd cluster health checking in cluster-init

### DIFF
--- a/board/mistify/rootfs_overlay/root/cluster-init
+++ b/board/mistify/rootfs_overlay/root/cluster-init
@@ -83,7 +83,7 @@ function do_until() {
 function etcd_cluster_healthy() {
     # Can't rely on `etcdctl cluster-health` exit code to determine cluster
     # health. Look for a response that doesn't contain "unhealthy"
-    ! $( etcdctl cluster-health | grep -q "unhealthy")
+    ! etcdctl cluster-health | grep -q "unhealthy"
 }
 
 function configure_network() {

--- a/board/mistify/rootfs_overlay/root/cluster-init
+++ b/board/mistify/rootfs_overlay/root/cluster-init
@@ -79,6 +79,13 @@ function do_until() {
     log "end"
 }
 
+# Check if cluster is healthy. Returns 0 if healthy, 1 if unhealthy
+function etcd_cluster_healthy() {
+    # Can't rely on `etcdctl cluster-health` exit code to determine cluster
+    # health. Look for a response that doesn't contain "unhealthy"
+    ! $( etcdctl cluster-health | grep -q "unhealthy")
+}
+
 function configure_network() {
     log "begin"
     rm -f /etc/systemd/network/*
@@ -204,7 +211,7 @@ function update_hypervisor0_etcd {
 
     log "restarting etcd"
     systemctl restart etcd
-    do_until 5 etcdctl cluster-health
+    do_until 5 etcd_cluster_healthy
     log "done"
 
     # Update the peerURLS using the member API
@@ -239,7 +246,7 @@ function add_hypervisor() {
     log "done"
 
     log "waiting for hypervisor. please start node$index"
-    do_until 5 etcdctl cluster-health
+    do_until 5 etcd_cluster_healthy
     log "done"
 
     log "end"


### PR DESCRIPTION
`etcdctl cluster-health` uses a zero exit code even for unhealthy clusters (non-zero is reserved for an error), so that call alone isn't sufficient to determine cluster health. Check for the absence of "unhealthy", which will appear in the output both if the cluster and if any individual member is unhealthy.

Side note: `grep -qv` might not do what you think it does.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-os/141)
<!-- Reviewable:end -->
