### PR TITLE
Mist 542 kernel rebuilds

### DIFF
--- a/buildmistify
+++ b/buildmistify
@@ -601,7 +601,6 @@ BR2_CCACHE_DIR=$builddir/.buildroot_ccache \
 BR2_DL_DIR=$downloaddir BR2_EXTERNAL=$projectdir \
 BR2_DEFAULT_KERNEL_HEADERS=$buildrootkernelheaders \
 GOROOT=$GOROOT -C $buildrootdir \
-$makeoption \
 $target"
 
 #+
@@ -710,7 +709,7 @@ else
   cd $buildrootdir
   ln -sf $logfilename $logdir/buildroot.log
   _envvars=`env | sort`
-  cat << EOF >$logfile
+  cat << EOF | tee $logfile
 ++++
 $id: Running make command:
 $makecommand

--- a/buildmistify
+++ b/buildmistify
@@ -64,12 +64,12 @@ Usage: ./buildmistify [options] [target]
         The repository from which to clone Buildroot. This is saved in the file
         $statedir/buildrooturi.
         [buildrooturi=`cat $statedir/buildrooturi`]
-    --buildroot <dir>
+    --buildrootdir <dir>
         Where Buildroot is to be installed. Using this option simplifies using a
         single Buildroot install for multiple projects OR using different
         versions of Buildroot for different projects. This is saved in the file
-        $statedir/buildroot.
-        [buildroot=`cat $statedir/buildroot`]
+        $statedir/buildrootdir.
+        [buildrootdir=`cat $statedir/buildrootdir`]
     --buildrootversion <version>
         Checkout Buildroot using a specified version. This can be a branch
         or tag name or even a commit ID. The version information is saved in the
@@ -178,7 +178,7 @@ gouri:,\
 godir:,\
 gotag:,\
 buildrooturi:,\
-buildroot:,\
+buildrootdir:,\
 buildrootversion:,\
 builddir:,\
 variant:,\
@@ -244,7 +244,7 @@ while [ $# -ge 1 ]; do
 	    buildrooturi=$2
 	    shift
 	    ;;
-	--buildroot)
+	--buildrootdir)
 	    buildrootdir=$2
 	    shift
 	    ;;
@@ -601,6 +601,7 @@ BR2_CCACHE_DIR=$builddir/.buildroot_ccache \
 BR2_DL_DIR=$downloaddir BR2_EXTERNAL=$projectdir \
 BR2_DEFAULT_KERNEL_HEADERS=$buildrootkernelheaders \
 GOROOT=$GOROOT -C $buildrootdir \
+$makeoption \
 $target"
 
 #+
@@ -706,8 +707,19 @@ else
   #+
   # Run the buildroot make.
   #-
+  cd $buildrootdir
   ln -sf $logfilename $logdir/buildroot.log
-  time $makecommand 2>&1 | tee $logfile
+  _envvars=`env | sort`
+  cat << EOF >$logfile
+++++
+$id: Running make command:
+$makecommand
+$id: Environment:
+$_envvars
+$id: Buildroot dir is: $buildrootdir
+----
+EOF
+  time $makecommand 2>&1 | tee -a $logfile
   rc=${PIPESTATUS[0]}
   message "The Mistify-OS build is complete."
   message "The log file is: $logfile"

--- a/scripts/variants.sh
+++ b/scripts/variants.sh
@@ -13,7 +13,7 @@ function config_contains () {
   #-
   opt=$1
   shift
- 
+
   for o in $*; do
     if [ "$1" == "$o" ]; then
       return 0
@@ -39,7 +39,7 @@ function merge_variant () {
   message "Merging files $1 and $2 into $3"
   message "Base file is: $1"
   sed_expression="s/^\(# \)\{0,1\}\(${prefix}_[a-zA-Z0-9_]*\)[= ].*/\2/p"
-  
+
   baselist=$(sed -n "$sed_expression" $1)
   variantlist=$(sed -n "$sed_expression" $2)
   run cp $1 $3
@@ -71,6 +71,21 @@ function variant_file () {
   eval "$3=$vf"
 }
 
+function copy_if_different () {
+    #+
+    # Parameters:
+    # 1 = source file
+    # 2 = destination file
+    #-
+    diff $1 $2 &> /dev/null
+    if [ $? -gt 0 ]; then
+        verbose Files $1 and $2 are different -- copying.
+        run cp $1 $2
+    else
+        verbose Files $1 and $2 are the same -- not copying.
+    fi
+}
+
 function use_variant () {
     #+
     # Parameters:
@@ -91,7 +106,7 @@ function use_variant () {
 	else
 	    verbose "Variant file doesn't exist. Copying $1 to $2"
 	fi
-	run cp $1 $2
+	copy_if_different $1 $2
 	return 0
     fi
 }


### PR DESCRIPTION
This corrects a problem which was triggering a build of the kernel on every run of buildmistify. While at it I changed a command line option to be consistent with its corresponding variable.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-os/142)
<!-- Reviewable:end -->
