### PR TITLE
Mist 621 go1.5.1

### DIFF
--- a/package/mistify/mistify-agent-libvirt/mistify-agent-libvirt.mk
+++ b/package/mistify/mistify-agent-libvirt/mistify-agent-libvirt.mk
@@ -16,6 +16,9 @@ GOPATH=$(O)/tmp/GOPATH
 define MISTIFY_AGENT_LIBVIRT_BUILD_CMDS
 	# GO apparently wants the install path to be independent of the
 	# build path. Use a temporary directory to do the build.
+	# NOTE: Appending -lrt to CGO_LDFLAGS is a temporary workaround for a link problem
+	# with alexzorin/libvirt-go. A solution has been suggested to the upstream but until
+	# it is merged appending -lrt here is a way to get the build to work.
 	mkdir -p $(GOPATH)/src/github.com/mistifyio/mistify-agent-libvirt
 	rsync -av --delete-after --exclude=.git --exclude-from=$(@D)/.gitignore \
 		$(@D)/ $(GOPATH)/src/github.com/mistifyio/mistify-agent-libvirt/
@@ -23,7 +26,7 @@ define MISTIFY_AGENT_LIBVIRT_BUILD_CMDS
 	GOROOT=$(GOROOT) \
 	PATH=$(GOROOT)/bin:$(PATH) \
 	CGO_CPPFLAGS=-I$(HOST_DIR)/usr/include \
-	CGO_LDFLAGS="-L$(TARGET_DIR)/lib -L$(TARGET_DIR)/usr/lib -Wl,-rpath-link,$(TARGET_DIR)/lib -Wl,-rpath-link,$(TARGET_DIR)/usr/lib" \
+	CGO_LDFLAGS="-L$(TARGET_DIR)/lib -L$(TARGET_DIR)/usr/lib -Wl,-rpath-link,$(TARGET_DIR)/lib -Wl,-rpath-link,$(TARGET_DIR)/usr/lib -lrt" \
 	GOPATH=$(GOPATH) make install DESTDIR=$(TARGET_DIR) \
 		-C $(GOPATH)/src/github.com/mistifyio/mistify-agent-libvirt
 	mv $(TARGET_DIR)/opt/mistify/sbin/mistify-libvirt  $(TARGET_DIR)/opt/mistify/sbin/mistify-agent-libvirt

--- a/scripts/install-go.sh
+++ b/scripts/install-go.sh
@@ -4,12 +4,88 @@
 # the googlesource repo so that URL is the default for this script. Of course
 # it can be overridden using the --gouri command line option.
 # NOTE: This relies upon the toolchainversion variable from the install-toolchain
-# script. This is because th path to the toolchain is embedded and different
+# script. This is because the path to the toolchain is embedded and different
 # versions of the toolchain can be selected.
 #-
 gouridefault=git@github.com:golang/go.git
 godirdefault=$PWD/go
-gotagdefault=go1.4.2
+gotagdefault=go1.5.1
+gobootstraptag=go1.4.2
+
+build-c-go () {
+    #+
+    # Parameters:
+    # 1 = The label to associate with the build.
+    # 2 = The tag to checkout from the repo.
+    #-
+    if [ -f $godir/.$1-built ]; then
+	message "build-c-go: Using go version $1."
+	return
+    fi
+    verbose "build-c-go: Building go version $1."
+    run mkdir -p $godir/$1
+    cd $godir/$1
+    verbose "Working directory is: $PWD"
+    if [ ! -d go ]; then
+	run git clone $gouri
+    fi
+    cd go
+    run git fetch $gouri
+    run git checkout $2
+    cd src
+    export GOOS=linux
+    export GOARCH=amd64
+    if [ -n "$TC_PREFIX_DIR" ]; then
+	export CC_FOR_TARGET="$TC_PREFIX_DIR/bin/${TC_PREFIX}-cc"
+	export CXX_FOR_TARGET="$TC_PREFIX_DIR/bin/${TC_PREFIX}-c++"
+    fi
+    export CGO_ENABLED=1
+
+    run ./make.bash
+
+    # Clean up
+    unset CC_FOR_TARGET
+    unset CXX_FOR_TARGET
+    unset CGO_ENABLED
+
+    touch $godir/.$1-built
+}
+
+build-go-go () {
+    #+
+    # Parameters:
+    # 1 = The label to associate with the build.
+    # 2 = The tag to checkout from the repo.
+    #-
+    if [ -f $godir/.$1-built ]; then
+	message "build-go-go: Using go version $1."
+	return
+    fi
+    bootstraplabel=$gobootstraptag-$toolchainversion
+    build-c-go $bootstraplabel $gobootstraptag
+
+    verbose "build-go-go: Building go version $1."
+    run mkdir -p $godir/$1
+    cd $godir/$1
+    verbose "Working directory is: $PWD"
+    if [ ! -d go ]; then
+	run git clone $gouri
+    fi
+    cd go
+    run git fetch $gouri
+    run git checkout $2
+    cd src
+    export GOROOT_BOOTSTRAP=$godir/$bootstraplabel/go
+    export GOOS=linux
+    export GOARCH=amd64
+
+    run ./make.bash
+
+    # Clean up
+    unset GOROOT_BOOTSTRAP
+
+    touch $godir/.$1-built
+}
 
 install-go () {
     #+
@@ -67,42 +143,23 @@ install-go () {
     GOROOT=$godir/$golabel/go
     verbose "The go binaries are located at: $GOROOT"
 
-    if [ -f $godir/.$golabel-built ]; then
-	message "Using go version $gotag."
-	return
-    fi
     #+
     # The go binaries don't exist.
     #-
-    if [ -n "$testing" ]; then
-	message "Just a test run -- not building the toolchain."
+    if [ -n "$dryrun" ]; then
+	message "Just a test run -- not building go."
 	verbose "./all.bash"
     else
-	run mkdir -p $godir/$golabel
-	cd $godir/$golabel
-	verbose "Working directory is: $PWD"
-	if [ ! -d go ]; then
-	    run git clone $gouri
+	#+
+	# With go version 1.5 and later all C source has been removed from
+	# the go sources. This means go is needed to build go and makes this
+	# a two stage build.
+	#-
+	minor=`echo $gotag | cut -d . -f 2`
+	if [ "$minor" -lt "5" ]; then
+	    build-c-go $golabel $gotag
+	else
+	    build-go-go $golabel $gotag
 	fi
-	cd go
-	run git fetch $gouri
-	run git checkout $gotag
-	cd src
-	export GOOS=linux
-	export GOARCH=amd64
-	if [ -n "$TC_PREFIX_DIR" ]; then
-	    export CC_FOR_TARGET="$TC_PREFIX_DIR/bin/${TC_PREFIX}-cc"
-	    export CXX_FOR_TARGET="$TC_PREFIX_DIR/bin/${TC_PREFIX}-c++"
-	fi
-	export CGO_ENABLED=1
-
-	run ./make.bash
-
-	# Clean up
-	unset CC_FOR_TARGET
-	unset CXX_FOR_TARGET
-	unset CGO_ENABLED
-
-	touch $godir/.$golabel-built
     fi
 }


### PR DESCRIPTION
This modifies the go install to support and default to go1.5.1. To build go1.5.1 a 1.4 version of go is needed. Because of this the go build is now two stage if building 1.5 or later. The first stage builds 1.4.2 using gcc (crosstool) if it doesn't already exist. The second stage then uses 1.4.2 to build 1.5.1.

In the process of testing this a bug was discovered in alexzorin/libvirt-go. A workaround for this bug was added to package/mistify/mistify-agent/libvirt/mistify-agent-libvirt.mk. Manny pushed a change upstream. Once the change has been merged into the upstream master this workaround can be removed (but won't cause any harm if left in place for a while).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-os/151)
<!-- Reviewable:end -->
