### PR TITLE
Mist 646 buildmistify cleanup

### DIFF
--- a/buildmistify
+++ b/buildmistify
@@ -7,6 +7,7 @@
 #-
 
 
+source scripts/mistify-functions.sh
 
 timestampfile=/tmp/buildmistify-ts
 
@@ -19,6 +20,8 @@ Usage: ./buildmistify [options] [target]
   the Mistify repository.
   Buildroot is configured to use an external toolchain. If the external
   toolchain is not present then it is installed before starting Buildroot.
+  Any of the options can be reset to their default value by passing "default"
+  as the parameter.
   Options:
     ==== external toolchain ====
     --tcuri <uri>
@@ -33,36 +36,46 @@ Usage: ./buildmistify [options] [target]
         $statedir/toolchaindir.
         [toolchaindir=`cat $statedir/toolchaindir`]
     --toolchainprefix <prefix>
-        This is the toolchain prefix to use to select a specific build of the
-        toolchain. This is saved in the file
+        This is the toolchain prefix to use to identify the intended target
+        architecture of the toolchain. This is saved in the file
         $statedir/toolchainprefix
         [toolchainprefix=`cat $statedir/toolchainprefix`]
     --toolchainversion <version>
         Checkout the toolchain using a specified version. This can be a branch
-        or tag name or even a commit ID. The version information is saved in the
-        file $statedir/toolchainversion.
+        or tag name or even a commit ID. This is used to build the path to where
+        the toolchain is cloned. This is saved in the file
+        $statedir/toolchainversion.
         [toolchainversion=`cat $statedir/toolchainversion`]
+    --toolchaininstallprefix <dir>
+        Where the toolchain should be installed. This is saved in the file
+        $statedir/toolchaininstallprefix
+        [toolchaininstallprefix=`cat $statedir/toolchaininstallprefix`]
     --toolchainreset
         Reset the toolchain related options to their defaults.
-    --newtoolchainbuild
-        Uses new makefile to build toolchain from source.
-        Feature flag, will eventually replace the shell script code in
-        install-toolchain.sh currently used to build.
-        ==== go ====
+    --tcartifacturi <uri>
+        The server on which pre-built toolchains are stored. This is used when
+        a pre-built toolchain is either copied to the server or installed from
+        the server. This is saved in the file
+        $statedir/tcartifacturi.
+        [tcartifacturi=`cat $statedir/tcartifacturi`]
+    ==== go ====
     --godir <dir>
         Where the GO source code is cloned to before building. This is saved in
         the file $statedir/godir.
         [godir=`cat $statedir/godir`]
-    --gouri default|<uri>
-        The repository from which to clone the GO source code. Use "default"
-        to reset to the default URI.
+    --gouri <uri>
+        The repository from which to clone the GO source code.
         This is saved in the file $statedir/gouri.
         [gouri=`cat $statedir/gouri`]
-    --gotag default|<tag>
+    --gotag <tag>
         The tag to use when fetching the GO source code from the repository.
-        Use "default" to reset to the default repository tag.
         This is saved in the file $statedir/gotag.
         [gotag=`cat $statedir/gotag`]
+    --gobootstraptag <tag>
+        The tag to use when fetching the GO source code from the repository for.
+        the version of go to use to bootstrap go 1.5 and latere.
+        This is saved in the file $statedir/gobootstraptag.
+        [gobootstraptag=`cat $statedir/gobootstraptag`]
     ==== buildroot ====
     --buildrooturi <uri>
         The repository from which to clone Buildroot. This is saved in the file
@@ -127,7 +140,7 @@ Usage: ./buildmistify [options] [target]
         [tcconfig=`cat $statedir/tcconfig 2>/dev/null || echo \\`]
     ==== other ====
     --resetdefaults
-        Reset options back to their default values.
+        Reset all options back to their default values.
     --noupdate
         Do not attempt to update buildroot or the toolchain from the repo.
     --verbose
@@ -161,17 +174,11 @@ Usage: ./buildmistify [options] [target]
   linux-menuconfig exit immediately after exiting the corresponding
   configuration utilities.
   Custom environment variables:
-    MISTIFY_DIR = Points to the directory in which buildmistify resides. This
+    MISTIFY_DIR Points to the directory in which buildmistify resides. This
     can then be used in the buildroot config to specify locations of files such
     as the config file.
 EOF
 }
-
-source scripts/mistify-functions.sh
-source scripts/install-toolchain.sh
-source scripts/install-go.sh
-source scripts/variants.sh
-
 
 #+
 # TODO: Add some quick checks to verify required tools are installed.
@@ -184,12 +191,14 @@ a=`getopt -l "\
 tcuri:,\
 toolchaindir:,\
 toolchainprefix:,\
+toolchaininstallprefix:,\
 toolchainversion:,\
 toolchainreset,\
-newtoolchainbuild,\
+tcartifacturi:,\
 gouri:,\
 godir:,\
 gotag:,\
+gobootstraptag:,\
 buildrooturi:,\
 buildrootdir:,\
 buildrootversion:,\
@@ -236,6 +245,10 @@ while [ $# -ge 1 ]; do
         toolchainprefix=$2
         shift
         ;;
+    --toolchaininstallprefix)
+        toolchaininstallprefix=$2
+        shift
+        ;;
     --toolchainversion)
         toolchainversion=$2
         shift
@@ -243,8 +256,9 @@ while [ $# -ge 1 ]; do
     --toolchainreset)
         toolchainreset=y
         ;;
-    --newtoolchainbuild)
-        newtoolchainbuild=y
+    --tcartifacturi)
+        tcartifacturi=$2
+        shift
         ;;
     --gouri)
         gouri=$2
@@ -256,6 +270,10 @@ while [ $# -ge 1 ]; do
         ;;
     --gotag)
         gotag=$2
+        shift
+        ;;
+    --gobootstraptag)
+        gobootstraptag=$2
         shift
         ;;
     --buildrooturi)
@@ -304,7 +322,7 @@ while [ $# -ge 1 ]; do
         tcconfig=$2
         shift
         ;;
-    --resetdefalts)
+    --resetdefaults)
         resetdefaults=y
         ;;
     --noupdate)
@@ -339,33 +357,53 @@ while [ $# -ge 1 ]; do
     shift
 done
 
-if [ ! -z "$resetdefaults" ]; then
-    reset_build_default buildrooturi
-    reset_build_default buildrootdir
-    reset_build_default buildrootversion
-    reset_build_default builddir
-    reset_build_default downloaddir
-    reset_build_default mconfig
-    reset_build_default kconfig
-    reset_build_default bbconfig
+defaults=(
+    tcuri=git@github.com:mistifyio/crosstool-ng.git
+    toolchaindir=$PWD/toolchain
+    toolchainprefix=x86_64-unknown-linux-gnu
+    toolchaininstallprefix=target-toolchain
+    toolchainversion=glibc-multilib-sdk
+    tcartifacturi=https://s3.amazonaws.com/omniti-mystify-artifacts/toolchain-artifacts
+    gouri=git@github.com:golang/go.git
+    godir=$PWD/go
+    gotag=go1.5.1
+    gobootstraptag=go1.4.2
+    variant=base
+    buildrooturi=git@github.com:mistifyio/buildroot.git
+    buildrootdir=$PWD/build/buildroot
+    buildrootversion=master
+    builddir=$PWD/build/mistify
+    downloaddir=$PWD/downloads
+    mconfig=$PWD/configs/mistify_defconfig
+    kconfig=$PWD/configs/mistify-kernel.config
+    bbconfig=$PWD/configs/mistify-busybox.config
+    tcconfig=$PWD/configs/mistify-tc-multilib.config
+)
+
+if [ -n "$toolchainreset" ]; then
+    for d in tcconfig tcuri toolchaindir toolchainprefix toolchainversion
+    do
+        verbose Resetting default: $d
+        reset_build_default $d
+    done
 fi
 
-#+
-# TODO: builtrootversion needs to be updated at release time to use the tag corresponding
-# to the release.
-#-
-buildrooturidefault=$(get_build_default buildrooturi git@github.com:mistifyio/buildroot.git)
-buildrootdirdefault=$(get_build_default buildrootdir $PWD/build/buildroot)
-buildrootversiondefault=$(get_build_default buildrootversion master)
+for v in "${defaults[@]}"
+do
+    if [ ! -z "$resetdefaults" ]; then
+        clear_build_variable $v
+    fi
+    init_build_variable $v
+done
 
-rootdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-builddirdefault=$(get_build_default builddir $PWD/build/mistify)
-downloaddirdefault=$(get_build_default downloaddir $PWD/downloads)
-mconfigdefault=$(get_build_default mconfig $PWD/configs/mistify_defconfig)
-kconfigdefault=$(get_build_default kconfig $PWD/configs/mistify-kernel.config)
-bbconfigdefault=$(get_build_default bbconfig $PWD/configs/mistify-busybox.config)
+if [ -n "$showusage" ]; then
+    usage
+    exit 0
+fi
 
-message "Root directory: $rootdir"
+source scripts/install-toolchain.sh
+source scripts/install-go.sh
+source scripts/variants.sh
 
 if [[ $# -ge 1 ]]; then
     target="$@"
@@ -375,20 +413,7 @@ else
     t=""
 fi
 
-if [ ! -e $statedir ]; then
-    mkdir -p $statedir
-fi
-
-#+
-# Determine the location of the Buildroot directory.
-# NOTE: The directory does not need to exist because the Buildroot init script will
-# create it if necessary.
-#-
-if [ -z "$buildrootdir" ]; then
-    buildrootdir=$buildrootdirdefault
-fi
 message "Using Buildroot located at: $buildrootdir"
-set_build_default buildrootdir $buildrootdir
 
 #+
 # Determine the configuration variant to use.
@@ -408,19 +433,8 @@ message "Using $variant configuration."
 
 export MISTIFY_VARIANT="$variant"
 
-#+
-# Determine the location of the build directory.
-# NOTE: The directory does not need to exist because the Buildroot make will
-# create it if necessary.
-#-
-if [ -z "$builddir" ]; then
-    builddir=$builddirdefault
-fi
-if [ ! -d "$builddir" ]; then
-    mkdir -p $builddir
-fi
+mkdir -p $builddir
 message "Build output directory is: $builddir"
-set_build_default builddir $builddir
 
 variantbuilddir=$builddir/$variantdir
 message "The variant build directory is: $variantbuilddir"
@@ -430,54 +444,16 @@ set_build_default variantbuilddir $variantbuilddir
 logdir=$variantbuilddir/logs
 mkdir -p $logdir
 
-#+
-# Determine the uri to use to fetch the Buildroot tool.
-#-
-if [ -z "$buildrooturi" ]; then
-    buildrooturi=$buildrooturidefault
-fi
 message "The Buildroot repository is: $buildrooturi"
-set_build_default buildrooturi $buildrooturi
-
-if [ -z "$buildrootversion" ]; then
-    buildrootversion=$buildrootversiondefault
-fi
 message "The Buildroot version is: $buildrootversion"
-
-if [ -z "$mconfig" ]; then
-    mconfig=$mconfigdefault
-fi
-
-if [ -z "$kconfig" ]; then
-    kconfig=$kconfigdefault
-fi
-
-if [ -z "$downloaddir" ]; then
-    downloaddir=$downloaddirdefault
-fi
-
-if [ -z "$bbconfig" ]; then
-    bbconfig=$bbconfigdefault
-fi
 
 if [ -z "$logfilename" ]; then
     logfilename=buildroot-`date +%y%m%d%H%M%S`.log
 fi
 
 if [ "$target" == "toolchain-build" ]; then
-    if [ ! -z "$useartifacts" ]; then
-        install-toolchain-from-artifact
-    elif [ ! -z "$newtoolchainbuild" ]; then
-        install-toolchain-from-source
-    else
-        install-toolchain
-    fi
-    exit 0
-fi
-
-if [ ! -z "$showusage" ]; then
-    usage
-    exit 0
+    install-toolchain
+    exit $?
 fi
 
 if [ ! -f $buildrootdir/README ]; then
@@ -498,7 +474,7 @@ if [ -n "$noupdate" ]; then
     warning Not fetching branches for buildroot.
 else
     message "Fetching Buildroot update from the remote repository."
-    git fetch
+    run git fetch
 fi
 
 run git checkout $buildrootversion
@@ -629,13 +605,7 @@ message "Project dir: $projectdir"
 #+
 # Be sure the toolchain is installed.
 #-
-if [ ! -z "$useartifacts" ]; then
-    install-toolchain-from-artifact
-elif [ ! -z "$newtoolchainbuild" ]; then
-    install-toolchain-from-source
-else
-    install-toolchain
-fi
+install-toolchain
 install-go
 
 #+
@@ -644,7 +614,7 @@ install-go
 export MISTIFY_DIR=$projectdir
 makecommand="\
 make O=$variantbuilddir \
-TOOLCHAIN_PATH=$TC_PREFIX_DIR TOOLCHAIN_PREFIX=$toolchainprefix \
+TOOLCHAIN_PATH=`toolchain-dir` TOOLCHAIN_PREFIX=$toolchainprefix \
 BR2_CCACHE_DIR=$builddir/.buildroot_ccache \
 BR2_DL_DIR=$downloaddir BR2_EXTERNAL=$projectdir \
 BR2_DEFAULT_KERNEL_HEADERS=$buildrootkernelheaders \
@@ -750,6 +720,7 @@ message "Logging the build output to: $logfile"
 if [ -n "$dryrun" ]; then
     message "Just a dry run -- not running make."
     verbose $makecommand
+    exit 0
 else
     #+
     # Run the buildroot make.

--- a/buildmistify
+++ b/buildmistify
@@ -381,7 +381,10 @@ defaults=(
 )
 
 if [ -n "$toolchainreset" ]; then
-    for d in tcconfig tcuri toolchaindir toolchainprefix toolchainversion
+    for d in \
+        tcconfig tcuri toolchaindir \
+        toolchainprefix toolchainversion \
+        tcartifacturi
     do
         verbose Resetting default: $d
         reset_build_default $d

--- a/buildmistify
+++ b/buildmistify
@@ -43,8 +43,12 @@ Usage: ./buildmistify [options] [target]
         file $statedir/toolchainversion.
         [toolchainversion=`cat $statedir/toolchainversion`]
     --toolchainreset
-	Reset the toolchain related options to their defaults.
-    ==== go ====
+        Reset the toolchain related options to their defaults.
+    --newtoolchainbuild
+        Uses new makefile to build toolchain from source.
+        Feature flag, will eventually replace the shell script code in
+        install-toolchain.sh currently used to build.
+        ==== go ====
     --godir <dir>
         Where the GO source code is cloned to before building. This is saved in
         the file $statedir/godir.
@@ -138,10 +142,6 @@ Usage: ./buildmistify [options] [target]
     --useartifacts
         Downloads/Extracts dependent artifacts instead of building from source.
         Currently supports toolchain ONLY.
-    --newtoolchainbuild
-        Uses new makefile to build toolchain from source.
-        Feature flag, will eventually replace the shell script code in
-        install-toolchain.sh currently used to build.
     -h|--help
         Display this usage.
     ==== special targets ====
@@ -186,6 +186,7 @@ toolchaindir:,\
 toolchainprefix:,\
 toolchainversion:,\
 toolchainreset,\
+newtoolchainbuild,\
 gouri:,\
 godir:,\
 gotag:,\
@@ -200,7 +201,6 @@ bbconfig:,\
 tcconfig:,\
 dryrun,\
 useartifacts,\
-newtoolchainbuild,\
 downloaddir:,\
 resetmasters,\
 resetdefaults,\
@@ -220,121 +220,121 @@ eval set -- $a
 
 while [ $# -ge 1 ]; do
     case "$1" in
-	--)
-	    shift
-	    break
-	    ;;
-	--tcuri)
-	    tcuri=$2
-	    shift
-	    ;;
-	--toolchaindir)
-	    toolchaindir=$2
-	    shift
-	    ;;
-	--toolchainprefix)
-	    toolchainprefix=$2
-	    shift
-	    ;;
-	--toolchainversion)
-	    toolchainversion=$2
-	    shift
-	    ;;
-	--toolchainreset)
-	    toolchainreset=y
-	    ;;
-	--gouri)
-	    gouri=$2
-	    shift
-	    ;;
-	--godir)
-	    godir=$2
-	    shift
-	    ;;
-	--gotag)
-	    gotag=$2
-	    shift
-	    ;;
-	--buildrooturi)
-	    buildrooturi=$2
-	    shift
-	    ;;
-	--buildrootdir)
-	    buildrootdir=$2
-	    shift
-	    ;;
-	--buildrootversion)
-	    buildrootversion=$2
-	    shift
-	    ;;
-	-b|--builddir)
-	    builddir=$2
-	    shift
-	    ;;
-	-d|--downloaddir)
-	    downloaddir=$2
-	    shift
-	    ;;
-	--resetmasters)
-	    resetmasters=y
-	    ;;
-	--variant)
-	    variant=$2
-	    # This variable helps handle the case where the variant is being
-	    # reset to the base ('').
-	    variantset=y
-	    shift
-	    ;;
-	-c|--mconfig)
-	    mconfig=$2
-	    shift
-	    ;;
-	-k|--kconfig)
-	    kconfig=$2
-	    shift
-	    ;;
-	--bbconfig)
-	    bbconfig=$2
-	    shift
-	    ;;
-	--tcconfig)
-	    tcconfig=$2
-	    shift
-	    ;;
-	--resetdefalts)
-	    resetdefaults=y
-	    ;;
-	--noupdate)
-	    noupdate=y
-	    ;;
-	--verbose)
-	    verbose=y
-	    ;;
-	-l|--logfile)
-	    logfilename=$2
-	    shift
-	    ;;
-	--viewlog)
-	    viewlog=y
-	    ;;
-	--dryrun)
-	    dryrun=y
-	    ;;
-	--useartifacts)
-	    useartifacts=y
-	    ;;
-	--newtoolchainbuild)
-	    newtoolchainbuild=y
-	    ;;
-	-h|--help)
-	    showusage=y
-	    ;;
-	# using getopt should avoid needing this catchall but just in case...
-	*)
-	    error "Invalid option: $1"
-	    usage
-	    exit 1
-	    ;;
+    --)
+        shift
+        break
+        ;;
+    --tcuri)
+        tcuri=$2
+        shift
+        ;;
+    --toolchaindir)
+        toolchaindir=$2
+        shift
+        ;;
+    --toolchainprefix)
+        toolchainprefix=$2
+        shift
+        ;;
+    --toolchainversion)
+        toolchainversion=$2
+        shift
+        ;;
+    --toolchainreset)
+        toolchainreset=y
+        ;;
+    --newtoolchainbuild)
+        newtoolchainbuild=y
+        ;;
+    --gouri)
+        gouri=$2
+        shift
+        ;;
+    --godir)
+        godir=$2
+        shift
+        ;;
+    --gotag)
+        gotag=$2
+        shift
+        ;;
+    --buildrooturi)
+        buildrooturi=$2
+        shift
+        ;;
+    --buildrootdir)
+        buildrootdir=$2
+        shift
+        ;;
+    --buildrootversion)
+        buildrootversion=$2
+        shift
+        ;;
+    -b|--builddir)
+        builddir=$2
+        shift
+        ;;
+    -d|--downloaddir)
+        downloaddir=$2
+        shift
+        ;;
+    --resetmasters)
+        resetmasters=y
+        ;;
+    --variant)
+        variant=$2
+        # This variable helps handle the case where the variant is being
+        # reset to the base ('').
+        variantset=y
+        shift
+        ;;
+    -c|--mconfig)
+        mconfig=$2
+        shift
+        ;;
+    -k|--kconfig)
+        kconfig=$2
+        shift
+        ;;
+    --bbconfig)
+        bbconfig=$2
+        shift
+        ;;
+    --tcconfig)
+        tcconfig=$2
+        shift
+        ;;
+    --resetdefalts)
+        resetdefaults=y
+        ;;
+    --noupdate)
+        noupdate=y
+        ;;
+    --verbose)
+        verbose=y
+        ;;
+    -l|--logfile)
+        logfilename=$2
+        shift
+        ;;
+    --viewlog)
+        viewlog=y
+        ;;
+    --dryrun)
+        dryrun=y
+        ;;
+    --useartifacts)
+        useartifacts=y
+        ;;
+    -h|--help)
+        showusage=y
+        ;;
+    # using getopt should avoid needing this catchall but just in case...
+    *)
+        error "Invalid option: $1"
+        usage
+        exit 1
+        ;;
     esac
     shift
 done
@@ -396,7 +396,7 @@ set_build_default buildrootdir $buildrootdir
 #-
 if [ -z "$variant" ]; then
     if [ "$variantset" == "y" ]; then
-	reset_build_default variant
+        reset_build_default variant
     fi
     variantdefault=$(get_build_default variant base)
     variant=$variantdefault
@@ -488,7 +488,7 @@ if [ ! -f $buildrootdir/README ]; then
     # git again to update just in case.
     #-
     if [ $? -gt 0 ]; then
-	die "Cloning Buildroot encountered an error."
+        die "Cloning Buildroot encountered an error."
     fi
 fi
 
@@ -512,10 +512,10 @@ fi
 run_ignore git symbolic-ref --short HEAD
 if [ $? -eq 0 ]; then
     if [ -n "$noupdate" ]; then
-	warning Not updating buildroot.
+        warning Not updating buildroot.
     else
-	message Updating from branch: $buildrootversion
-	run git pull
+        message Updating from branch: $buildrootversion
+        run git pull
     fi
 else
     message Buildroot version $buildrootversion is not a branch. Not updating.
@@ -538,18 +538,18 @@ if [ -f $mconfig ]; then
     verbose "Variant: $variant"
     use_variant $mconfig $brc $variant
     if [ $? -gt 0 ]; then
-	die "Could not copy the Buildroot config file."
+        die "Could not copy the Buildroot config file."
     fi
     message "Config file $mconfig copied to $brc"
     set_build_default mconfig $mconfig
 else
-  case "$target" in
-    "menuconfig" | "nconfig")
-	;;
-    *)
-	die "The config file doesn't exist. Run $0 menuconfig."
-	;;
-  esac
+    case "$target" in
+        "menuconfig" | "nconfig")
+            ;;
+        *)
+            die "The config file doesn't exist. Run $0 menuconfig."
+            ;;
+    esac
 fi
 
 #+
@@ -562,16 +562,16 @@ brkc=$variantbuilddir/build/linux-`grep BR2_LINUX_KERNEL_VERSION $brc | cut -d "
 verbose "Kernel configuration file: $brkc"
 if [ -f $brkc ]; then
     if [ -f $kconfig ]; then
-	use_variant $kconfig $brkc $variant
-	if [ $? -gt 0 ]; then
-	    die "Could not copy the kernel config file."
-	fi
-	message "Config file $kconfig copied to $brkc"
-	set_build_default kconfig $kconfig
+        use_variant $kconfig $brkc $variant
+        if [ $? -gt 0 ]; then
+            die "Could not copy the kernel config file."
+        fi
+        message "Config file $kconfig copied to $brkc"
+        set_build_default kconfig $kconfig
     else
-	if [[ "$target" != "linux-menuconfig" ]]; then
-	    die "The kernel config file doesn't exist. Run ./buildmistify linux-menuconfig."
-	fi
+        if [[ "$target" != "linux-menuconfig" ]]; then
+            die "The kernel config file doesn't exist. Run ./buildmistify linux-menuconfig."
+        fi
     fi
 fi
 
@@ -584,17 +584,17 @@ bbc=`ls -d $variantbuilddir/build/busybox-*`/.config
 
 if [ -f $bbc ]; then
     if [ -f $bbconfig ]; then
-	use_variant $bbconfig $bbc $variant
-	if [ $? -gt 0 ]; then
-	    warning "Busybox hasn't been built yet."
-	fi
-	message "Config file $bbconfig copied to $bbc"
-	set_build_default bbconfig $bbconfig
+        use_variant $bbconfig $bbc $variant
+        if [ $? -gt 0 ]; then
+            warning "Busybox hasn't been built yet."
+        fi
+        message "Config file $bbconfig copied to $bbc"
+        set_build_default bbconfig $bbconfig
     else
-	if [[ "$target" != "busybox-menuconfig" ]]; then
-	    error "The BusyBox config file doesn't exist."
-	    die "Run ./buildmistify busybox-menuconfig."
-	fi
+        if [[ "$target" != "busybox-menuconfig" ]]; then
+            error "The BusyBox config file doesn't exist."
+            die "Run ./buildmistify busybox-menuconfig."
+        fi
     fi
 fi
 
@@ -613,13 +613,13 @@ message "The Buildroot download directory is: $downloaddir"
 #-
 if [ -n "$resetmasters" ]; then
     if [ -d $downloaddir ]; then
-	p=$downloaddir/*-master.tar*
-	if ls $p 1> /dev/null 2>&1; then
-	for f in `ls $p`; do
-	    warning "Removing cached master branch file: $f"
-	    rm $f
-	done
-	fi
+        p=$downloaddir/*-master.tar*
+        if ls $p 1> /dev/null 2>&1; then
+            for f in `ls $p`; do
+                warning "Removing cached master branch file: $f"
+                rm $f
+            done
+        fi
     fi
 fi
 
@@ -656,85 +656,85 @@ $target"
 #-
 case "$target" in
     "menuconfig" | "nconfig")
-	touch $timestampfile
-	verbose "Current directory is: $PWD"
-	$makecommand
-	if [[ ! -f $mconfig || $brc -nt $timestampfile ]]; then
-	    #+
-	    # NOTE: The buildroot config option BR2_DEFCONFIG
-	    # needs to point to the config file so that buildroot will copy the correct
-	    # file on the first build.
-	    #-
-	   update_variant $brc $mconfig $variant
-	    if [ $? -gt 0 ]; then
-		error "Failed to save $mconfig"
-		exit 1
-	    fi
-	    tip "Use $0 to build Mistify using the new configuration."
-	    if [ -z "$variant" ]; then
-		message "New config file at $brc saved to $mconfig"
-	    else
-		message "The configuration variant saved to $variant"
-	    fi
-	fi
-	rm -f $timestampfile
-	exit
-	;;
+        touch $timestampfile
+        verbose "Current directory is: $PWD"
+        $makecommand
+        if [[ ! -f $mconfig || $brc -nt $timestampfile ]]; then
+            #+
+            # NOTE: The buildroot config option BR2_DEFCONFIG
+            # needs to point to the config file so that buildroot will copy the correct
+            # file on the first build.
+            #-
+            update_variant $brc $mconfig $variant
+            if [ $? -gt 0 ]; then
+                error "Failed to save $mconfig"
+                exit 1
+            fi
+            tip "Use $0 to build Mistify using the new configuration."
+            if [ -z "$variant" ]; then
+                message "New config file at $brc saved to $mconfig"
+            else
+                message "The configuration variant saved to $variant"
+            fi
+        fi
+        rm -f $timestampfile
+        exit
+        ;;
     "xconfig" | "gconfig")
-	error "Configuration tool $target is not supported."
-	exit 1
-	;;
+        error "Configuration tool $target is not supported."
+        exit 1
+        ;;
     "linux-menuconfig")
-	#+
-	# NOTE: The buildroot config option BR2_LINUX_KERNEL_CUSTOM_CONFIG_FILE
-	# needs to point to the config file so that buildroot will copy the correct
-	# file on the first build.
-	#-
-	touch $timestampfile
-	$makecommand
-	if [[ ! -f $kconfig || $brkc -nt $timestampfile ]]; then
-	    update_variant $brkc $kconfig $variant
-	    if [ $? -gt 0 ]; then
-		error "Failed to save $kconfig"
-		exit 1
-	    fi
-	    tip "Use $0 to build Mistify using the new configuration."
-	    if [ -z "$variant" ]; then
-		message "New kernel config file at $brkc saved to $kconfig"
-	    else
-		message "The kernel configuration variant saved to $variant"
-	    fi
-	fi
-	rm -f $timestampfile
-	exit
-	;;
+        #+
+        # NOTE: The buildroot config option BR2_LINUX_KERNEL_CUSTOM_CONFIG_FILE
+        # needs to point to the config file so that buildroot will copy the correct
+        # file on the first build.
+        #-
+        touch $timestampfile
+        $makecommand
+        if [[ ! -f $kconfig || $brkc -nt $timestampfile ]]; then
+            update_variant $brkc $kconfig $variant
+            if [ $? -gt 0 ]; then
+                error "Failed to save $kconfig"
+                exit 1
+            fi
+            tip "Use $0 to build Mistify using the new configuration."
+            if [ -z "$variant" ]; then
+                message "New kernel config file at $brkc saved to $kconfig"
+            else
+                message "The kernel configuration variant saved to $variant"
+            fi
+        fi
+        rm -f $timestampfile
+        exit
+        ;;
     "busybox-menuconfig")
-	#+
-	# NOTE: The buildroot config option BR2_PACKAGE_BUSYBOX_CONFIG
-	# needs to point to the config file so that buildroot will copy the correct
-	# file on the first build.
-	#-
-	touch $timestampfile
-	$makecommand
-	# NOTE: May want to use grep instead of a timestamp compare.
-	if [[ ! -f $bbconfig || $bbc -nt $timestampfile ]]; then
-	    update_variant $bbc $bbconfig $variant
-	    if [ $? -gt 0 ]; then
-		error "Failed to save $bbconfig"
-		exit 1
-	    fi
-	    tip "Use $0 to build Mistify using the new configuration."
-	    if [ -z "$variant" ]; then
-		message "New BusyBox config file $bbc saved to $bbconfig"
-	    else
-		message "The BusyBox configuration variant saved to $variant"
-	    fi
-	fi
-	rm -f $timestampfile
-	exit
-	;;
+        #+
+        # NOTE: The buildroot config option BR2_PACKAGE_BUSYBOX_CONFIG
+        # needs to point to the config file so that buildroot will copy the correct
+        # file on the first build.
+        #-
+        touch $timestampfile
+        $makecommand
+        # NOTE: May want to use grep instead of a timestamp compare.
+        if [[ ! -f $bbconfig || $bbc -nt $timestampfile ]]; then
+            update_variant $bbc $bbconfig $variant
+            if [ $? -gt 0 ]; then
+                error "Failed to save $bbconfig"
+                exit 1
+            fi
+            tip "Use $0 to build Mistify using the new configuration."
+            if [ -z "$variant" ]; then
+                message "New BusyBox config file $bbc saved to $bbconfig"
+            else
+                message "The BusyBox configuration variant saved to $variant"
+            fi
+        fi
+        rm -f $timestampfile
+        exit
+        ;;
     *)
-	;;
+        ;;
 esac
 
 #+
@@ -771,11 +771,11 @@ EOF
     message "The Mistify-OS build is complete."
     message "The log file is: $logfile"
     if [ $rc -gt 0 ]; then
-	error "Make complained about a build problem (see $logfile)."
-	if [ -n "$viewlog" ]; then
-	    less $logfile
-	fi
-	exit 1
+        error "Make complained about a build problem (see $logfile)."
+        if [ -n "$viewlog" ]; then
+            less $logfile
+        fi
+        exit 1
     fi
 fi
 
@@ -812,4 +812,3 @@ message "initrd.buildroot: The RAM disk."
 if [ -e $imagedir ]; then
     ls -l $imagedir
 fi
-

--- a/scripts/Makefile-toolchain
+++ b/scripts/Makefile-toolchain
@@ -77,13 +77,6 @@ endef
 
 .Phony: build clean fullclean dist distclean version tagformat
 
-# Needed for ct-ng build script
-export TC_PREFIX=$(arch)
-export TC_ARCH_SUFFIX=$(version_extra)-$(version)
-export TC_PREFIX_DIR=$(build_output_dir)
-export TC_LOCAL_TARBALLS_DIR=$(downloaddir)
-
-# all: cleanonchange.cache build dist
 all: $(downloaddir)/$(toolchain_tar_file)
 
 $(tcconfig):;

--- a/scripts/Makefile-toolchain
+++ b/scripts/Makefile-toolchain
@@ -1,17 +1,79 @@
-root_dir = $(shell pwd)
+#+
+# Some helpful macros.
+#-
+this_makefile = $(notdir $(lastword $(MAKEFILE_LIST)))
 
-build_dir = $(root_dir)/target
-build_output_dir = $(build_dir)/compiled_output
-download_dir = $(HOME)/.toolchain/downloads
-distributions_dir = $(build_dir)/distributions
+define message
+  $(info $(this_makefile): $(1))
+endef
 
-version = 1.21.0-SNAPSHOT
-arch = x86_64-unknown-linux-gnu
-version_extra = base
+define warn
+  $(warning $(this_makefile) warning: $(1))
+endef
 
-config_file = $(root_dir)/configs/mistify-tc.config
-config_status_file = config.status
-distribution = $(distributions_dir)/crosstool-ng-$(arch)-$(version)-$(version_extra).tar.gz
+define err
+  $(warning $(this_makefile) error: $(1))
+endef
+
+define die
+  $(error $(this_makefile): $(1))
+endef
+
+#+
+# This make file is designed to be called from the buildmistify
+# install-toolchain.sh script but can also be used from the command line.
+# It performs all the steps needed to clone the toolchain source from a git
+# repo (typically github) and build the final toolchain.
+# Parameters are passed from the buildmistify script on the make command line
+# as variable definitins which override the following variables. For consistency,
+# the variable names are those used by the buildmistify script.
+# To simplify use directly from the command line meaningful default values are
+# provided. The buildmistify help describes the meaning of each of these variables.
+#-
+$(call message, $(shell pwd))
+tcuri = git@github.com:mistifyio/crosstool-ng.git
+$(call message, "tcuri = $(tcuri)" )
+toolchaindir = $(shell pwd)/toolchain
+$(call message, "toolchaindir = $(toolchaindir)" )
+toolchainprefix = x86_64-unknown-linux-gnu
+$(call message, "toolchainprefix = $(toolchainprefix)" )
+toolchaininstallprefix = toolchain
+$(call message, "toolchaininstallprefix = $(toolchaininstallprefix)" )
+toolchainversion = glibc-multilib-sdk
+$(call message, "toolchainversion = $(toolchainversion)" )
+variant = base
+$(call message, "variant = $(variant)" )
+tcartifacturi = https://s3.amazonaws.com/omniti-mystify-artifacts/toolchain-artifacts
+$(call message, "tcartifacturi = $(tcartifacturi)" )
+tcconfig = $(shell pwd)/configs/mistify-tc-multilib.config
+$(call message, "tcconfig = $(tcconfig)" )
+downloaddir = $(shell pwd)/downloads
+$(call message, "downloaddir = $(downloaddir)" )
+verbose = n
+$(call message, "verbose = $(verbose)" )
+
+#+
+# Internal variables derived from the buildmistify commandline variables and
+# passed to this makefile by the buildmistify:install-toolchain.sh script.
+#-
+toolchain_name_prefix=crosstool-ng
+$(call message, "toolchain_name_prefix = $(toolchain_name_prefix)")
+toolchain_base_name = $(toolchain_name_prefix)-$(toolchainprefix)-$(toolchainversion)-$(variant)
+$(call message, "toolchain_base_name = $(toolchain_base_name)")
+toolchain_tar_file = $(toolchain_base_name).tgz
+$(call message, "toolchain_tar_file = $(toolchain_tar_file)")
+toolchainartifact_url = $(tcartifacturi)/$(toolchain_tar_file)
+$(call message, "toolchainartifact_url = $(toolchainartifact_url)")
+toolchain_variation_dir = $(toolchaindir)/build-$(toolchain_base_name)
+$(call message, "toolchain_variation_dir = $(toolchain_variation_dir)")
+toolchain_install_dir = $(toolchaindir)/$(toolchain_base_name)
+$(call message, "toolchain_install_dir = $(toolchain_install_dir)")
+
+toolchain_target_file = $(toolchain_install_dir)/bin/$(toolchainprefix)-gcc
+
+define run_in_tc_dir
+  cd $(toolchain_variation_dir) && $(1)
+endef
 
 .Phony: build clean fullclean dist distclean version tagformat
 
@@ -19,75 +81,95 @@ distribution = $(distributions_dir)/crosstool-ng-$(arch)-$(version)-$(version_ex
 export TC_PREFIX=$(arch)
 export TC_ARCH_SUFFIX=$(version_extra)-$(version)
 export TC_PREFIX_DIR=$(build_output_dir)
-export TC_LOCAL_TARBALLS_DIR=$(download_dir)
+export TC_LOCAL_TARBALLS_DIR=$(downloaddir)
 
-$(info Config file is $(config_file))
-$(info TC_PREFIX is ${TC_PREFIX})
-$(info TC_ARCH_SUFFIX is ${TC_ARCH_SUFFIX})
-$(info TC_PREFIX_DIR is ${TC_PREFIX_DIR})
-$(info TC_LOCAL_TARBALLS_DIR is ${TC_LOCAL_TARBALLS_DIR})
-$(info )
+# all: cleanonchange.cache build dist
+all: $(downloaddir)/$(toolchain_tar_file)
 
-all: cleanonchange.cache build dist
-
-$(config_file):;
+$(tcconfig):;
 
 $(config_status_file):;
 
-cleanonchange.cache: $(config_file)
-	-rm -rf $(build_output_dir)
-	if [ -f ct-ng ]; then ./ct-ng distclean; fi;
-	-rm $(config_status_file)
-	touch cleanonchange.cache
+$(toolchain_variation_dir):
+	git clone $(tcuri) $(toolchain_variation_dir)
 
-$(download_dir):
-	mkdir -p $(download_dir)
+$(toolchain_variation_dir)/.toolchainversion.$(toolchainversion): \
+  $(toolchain_variation_dir)
+	$(call run_in_tc_dir, \
+		git fetch)
+	$(call run_in_tc_dir, \
+		git checkout $(toolchainversion))
+	$(call run_in_tc_dir, \
+		git symbolic-ref --short HEAD && \
+		if [ $$? -eq 0 ]; then \
+			echo "Updating from branch: $(toolchainversion)"; \
+			git pull; \
+		fi)
+	touch $@
 
-$(build_output_dir):
-	mkdir -p $(build_output_dir)
+$(downloaddir):
+	mkdir -p $(downloaddir)
 
-$(distributions_dir):
-	mkdir -p $(distributions_dir)
+$(toolchain_variation_dir)/.config: $(tcconfig) \
+  $(toolchain_variation_dir)/.toolchainversion.$(toolchainversion)
+	cp $< $@
+	rm -rf $(toolchain_install_dir)
 
-.config: $(config_file)
-	cp $(config_file) .config
+$(toolchain_variation_dir)/configure: $(toolchain_variation_dir)/.config
+	$(call run_in_tc_dir, ./bootstrap )
 
-createbuildirs: | $(download_dir) $(build_output_dir) $(distributions_dir)
+#+
+# The toolchain makefile needs to be modified because it is being called
+# from this makefile. A variable is used here for two reasons. One, it's
+# easier to maintain the pattern and two, it can be overriden if necessary.
+#-
+fix_makefile_pattern = s/MAKELEVEL),0/MAKELEVEL),1/g
+$(toolchain_variation_dir)/Makefile: $(toolchain_variation_dir)/configure
+	$(call run_in_tc_dir, ./configure --enable-local)
+	$(call run_in_tc_dir, \
+	  sed -i.bak '$(fix_makefile_pattern)' Makefile \
+	)
 
-bootstraptoolchain.cache: .config
-	./bootstrap
-	touch bootstraptoolchain.cache
+$(toolchain_variation_dir)/ct-ng: $(toolchain_variation_dir)/Makefile
+	$(call run_in_tc_dir, make)
 
-configuretoolchain.cache: bootstraptoolchain.cache $(config_status_file)
-	./configure --enable-local --prefix=$(root_dir)
-	touch configuretoolchain.cache
+$(toolchain_target_file): \
+  $(toolchain_variation_dir)/ct-ng
+	$(call run_in_tc_dir, \
+	export TC_ARCH_SUFFIX=-$(toolchainversion); \
+    export TC_PREFIX=$(toolchainprefix); \
+    export TC_PREFIX_DIR=$(toolchain_install_dir); \
+    export TC_LOCAL_TARBALLS_DIR=$(downloaddir); \
+	time ./ct-ng build 2>&1 | tee tc-`date +%y%m%d%H%M%S`.log \
+	)
 
-ctng.cache: configuretoolchain.cache
-	sed -i.bak 's/MAKELEVEL),0/MAKELEVEL),1/g' Makefile
-	make -f Makefile
-	touch ctng.cache
+$(downloaddir)/$(toolchain_tar_file): \
+  $(toolchain_install_dir)/bin/$(toolchainprefix)-gcc
+	mkdir -p $(@D)
+	tar cvzf $@ -C $(toolchaindir) $(toolchain_base_name)
 
-build: createbuildirs ctng.cache
-	time ./ct-ng build
+build: $(toolchain_target_file)
 
-dist:
-	tar cvzf $(distribution) -C $(build_output_dir) .
+dist: $(downloaddir)/$(toolchain_tar_file)
 
 distclean:
-	-rm $(distributions_dir)/*
+	-rm $(downloaddir)/$(toolchain_tar_file)
 
 clean:
-	-rm -rf $(build_output_dir)
-	if [ -f ct-ng ]; then ./ct-ng distclean; fi;
+	-rm -rf $(toolchain_install_dir)
+	$(call run_in_tc_dir,
+	  if [ -f ct-ng ]; then ./ct-ng distclean; fi;
+	)
 
-fullclean: clean
-	-rm $(config_status_file)
+fullclean:
+	-rm -rf $(toolchain_variation_dir)
 
-menuconfig: configuretoolchain.cache
-	./ct-ng menuconfig
+toolchain-menuconfig: $(toolchain_variation_dir)/ct-ng
+	$(call run_in_tc_dir,
+	  ./ct-ng menuconfig)
 
 version:
-	@echo $(version)
+	@echo $(toolchainversion)
 
 tagformat:
-	@echo $(arch)-{new_version}-$(version_extra)
+	@echo $(toolchain_base_name)

--- a/scripts/install-go.sh
+++ b/scripts/install-go.sh
@@ -7,11 +7,6 @@
 # script. This is because the path to the toolchain is embedded and different
 # versions of the toolchain can be selected.
 #-
-gouridefault=git@github.com:golang/go.git
-godirdefault=$PWD/go
-gotagdefault=go1.5.1
-gobootstraptag=go1.4.2
-
 build-c-go () {
     #+
     # Parameters:
@@ -96,54 +91,11 @@ build-go-go () {
 }
 
 install-go () {
-    #+
-    # Determine the location of the go directory.
-    #-
-    if [ -z "$godir" ]; then
-        if [ -f $statedir/godir ]; then
-            godir=`cat $statedir/godir`
-        else
-            godir=$godirdefault
-        fi
-        message "Using go located at: $godir"
-    fi
-    eval godir=$godir
-    verbose "Building go in: $godir"
-    echo $godir >$statedir/godir
+    message "Building go in: $godir"
 
-    #+
-    # Determine the uri to use to fetch the go source.
-    #-
-    if [ -z "$gouri" ]; then
-        if [ -f $statedir/gouri ]; then
-            gouri=`cat $statedir/gouri`
-        else
-            gouri=$gouridefault
-        fi
-    fi
-    if [[ "$gouri" == "default" ]]; then
-        warning "Resetting the GO repository URI to the default: $gouridefault."
-        gouri=$gouridefault
-    fi
     message "The go source repository is: $gouri"
-    echo $gouri >$statedir/gouri
 
-    #+
-    # Determine the tag or branch to use to fetch the go source.
-    #-
-    if [ -z "$gotag" ]; then
-        if [ -f $statedir/gotag ]; then
-            gotag=`cat $statedir/gotag`
-        else
-            gotag=$gotagdefault
-        fi
-    fi
-    if [[ "$gotag" == "default" ]]; then
-        warning "Resetting the GO repository tag to the default: $gotagdefault."
-        gotag=$gotagdefault
-    fi
     message "The go branch or tag is: $gotag"
-    echo $gotag >$statedir/gotag
 
     golabel=$gotag-$toolchainversion
     verbose The Go label is: $golabel

--- a/scripts/install-go.sh
+++ b/scripts/install-go.sh
@@ -19,19 +19,19 @@ build-c-go () {
     # 2 = The tag to checkout from the repo.
     #-
     if [ -f $godir/.$1-built ]; then
-	message "build-c-go: Using go version $1."
-	return
+        message "build-c-go: Using go version $1."
+    return
     fi
     verbose "build-c-go: Building go version $1."
     if [ -n "$dryrun" ]; then
-	message "build-c-go: Just a test run -- not building go."
-	return
+        message "build-c-go: Just a test run -- not building go."
+        return
     fi
     run mkdir -p $godir/$1
     cd $godir/$1
     verbose "Working directory is: $PWD"
     if [ ! -d go ]; then
-	run git clone $gouri
+        run git clone $gouri
     fi
     cd go
     run git fetch $gouri
@@ -40,8 +40,8 @@ build-c-go () {
     export GOOS=linux
     export GOARCH=amd64
     if [ -n "$TC_PREFIX_DIR" ]; then
-	export CC_FOR_TARGET="$TC_PREFIX_DIR/bin/${TC_PREFIX}-cc"
-	export CXX_FOR_TARGET="$TC_PREFIX_DIR/bin/${TC_PREFIX}-c++"
+        export CC_FOR_TARGET="$TC_PREFIX_DIR/bin/${TC_PREFIX}-cc"
+        export CXX_FOR_TARGET="$TC_PREFIX_DIR/bin/${TC_PREFIX}-c++"
     fi
     export CGO_ENABLED=1
 
@@ -62,22 +62,22 @@ build-go-go () {
     # 2 = The tag to checkout from the repo.
     #-
     if [ -f $godir/.$1-built ]; then
-	message "build-go-go: Using go version $1."
-	return
+        message "build-go-go: Using go version $1."
+        return
     fi
     bootstraplabel=$gobootstraptag-$toolchainversion
     build-c-go $bootstraplabel $gobootstraptag
 
     verbose "build-go-go: Building go version $1."
     if [ -n "$dryrun" ]; then
-	message "build-go-go: Just a test run -- not building go."
-	return
+        message "build-go-go: Just a test run -- not building go."
+        return
     fi
     run mkdir -p $godir/$1
     cd $godir/$1
     verbose "Working directory is: $PWD"
     if [ ! -d go ]; then
-	run git clone $gouri
+        run git clone $gouri
     fi
     cd go
     run git fetch $gouri
@@ -100,12 +100,12 @@ install-go () {
     # Determine the location of the go directory.
     #-
     if [ -z "$godir" ]; then
-	if [ -f $statedir/godir ]; then
-	    godir=`cat $statedir/godir`
-	else
-	    godir=$godirdefault
-	fi
-	message "Using go located at: $godir"
+        if [ -f $statedir/godir ]; then
+            godir=`cat $statedir/godir`
+        else
+            godir=$godirdefault
+        fi
+        message "Using go located at: $godir"
     fi
     eval godir=$godir
     verbose "Building go in: $godir"
@@ -115,15 +115,15 @@ install-go () {
     # Determine the uri to use to fetch the go source.
     #-
     if [ -z "$gouri" ]; then
-	if [ -f $statedir/gouri ]; then
-	    gouri=`cat $statedir/gouri`
-	else
-	    gouri=$gouridefault
-	fi
+        if [ -f $statedir/gouri ]; then
+            gouri=`cat $statedir/gouri`
+        else
+            gouri=$gouridefault
+        fi
     fi
     if [[ "$gouri" == "default" ]]; then
-      warning "Resetting the GO repository URI to the default: $gouridefault."
-      gouri=$gouridefault
+        warning "Resetting the GO repository URI to the default: $gouridefault."
+        gouri=$gouridefault
     fi
     message "The go source repository is: $gouri"
     echo $gouri >$statedir/gouri
@@ -132,15 +132,15 @@ install-go () {
     # Determine the tag or branch to use to fetch the go source.
     #-
     if [ -z "$gotag" ]; then
-	if [ -f $statedir/gotag ]; then
-	    gotag=`cat $statedir/gotag`
-	else
-	    gotag=$gotagdefault
-	fi
+        if [ -f $statedir/gotag ]; then
+            gotag=`cat $statedir/gotag`
+        else
+            gotag=$gotagdefault
+        fi
     fi
     if [[ "$gotag" == "default" ]]; then
-      warning "Resetting the GO repository tag to the default: $gotagdefault."
-      gotag=$gotagdefault
+        warning "Resetting the GO repository tag to the default: $gotagdefault."
+        gotag=$gotagdefault
     fi
     message "The go branch or tag is: $gotag"
     echo $gotag >$statedir/gotag
@@ -159,12 +159,12 @@ install-go () {
     #-
     major=`echo $gotag | cut -d . -f 1`
     if [ ! "$major" == "go1" ]; then
-	die Only go1.x.x supported at this time.
+        die Only go1.x.x supported at this time.
     fi
     minor=`echo $gotag | cut -d . -f 2`
     if [ "$minor" -lt "5" ]; then
-	build-c-go $golabel $gotag
+        build-c-go $golabel $gotag
     else
-	build-go-go $golabel $gotag
+        build-go-go $golabel $gotag
     fi
 }

--- a/scripts/install-go.sh
+++ b/scripts/install-go.sh
@@ -32,20 +32,8 @@ build-c-go () {
     run git fetch $gouri
     run git checkout $2
     cd src
-    export GOOS=linux
-    export GOARCH=amd64
-    if [ -n "$TC_PREFIX_DIR" ]; then
-        export CC_FOR_TARGET="$TC_PREFIX_DIR/bin/${TC_PREFIX}-cc"
-        export CXX_FOR_TARGET="$TC_PREFIX_DIR/bin/${TC_PREFIX}-c++"
-    fi
-    export CGO_ENABLED=1
 
     run ./make.bash
-
-    # Clean up
-    unset CC_FOR_TARGET
-    unset CXX_FOR_TARGET
-    unset CGO_ENABLED
 
     touch $godir/.$1-built
 }
@@ -79,8 +67,6 @@ build-go-go () {
     run git checkout $2
     cd src
     export GOROOT_BOOTSTRAP=$godir/$bootstraplabel/go
-    export GOOS=linux
-    export GOARCH=amd64
 
     run ./make.bash
 
@@ -114,9 +100,21 @@ install-go () {
         die Only go1.x.x supported at this time.
     fi
     minor=`echo $gotag | cut -d . -f 2`
+    export GOOS=linux
+    export GOARCH=amd64
+    export CC_FOR_TARGET="${toolchain_install_dir}/bin/${toolchainprefix}-cc"
+    export CXX_FOR_TARGET="${toolchain_install_dir}/bin/${toolchainprefix}-c++"
+    export CGO_ENABLED=1
     if [ "$minor" -lt "5" ]; then
         build-c-go $golabel $gotag
     else
         build-go-go $golabel $gotag
     fi
+    # Clean up
+    unset GOOS
+    unset GOARCH
+    unset CC_FOR_TARGET
+    unset CXX_FOR_TARGET
+    unset CGO_ENABLED
+
 }

--- a/scripts/install-toolchain.sh
+++ b/scripts/install-toolchain.sh
@@ -37,9 +37,9 @@ build-toolchain () {
     #-
     mkdir -p $toolchaindir/variations
     if [ ! -f $toolchainconfigured ]; then
-	message "Configuring the toolchain build."
-	config-toolchain $toolchaindir
-	touch $toolchainconfigured
+        message "Configuring the toolchain build."
+        config-toolchain $toolchaindir
+        touch $toolchainconfigured
     fi
     cp $tcconfig $tcc
     message "Config file $tcconfig copied to $tcc"
@@ -49,33 +49,33 @@ build-toolchain () {
     tail build.log | grep "Build completed"
 
     if [ $? -gt 0 ]; then
-	die "The toolchain build failed."
+        die "The toolchain build failed."
     fi
     touch $toolchainbuilt
 }
 
 download-toolchain-artifact () {
-  mkdir -p $downloaddir
+    mkdir -p $downloaddir
 
-  message "Downloading toolchain artifact from $toolchainartifact_url"
-  wget -nc $toolchainartifact_url -O $downloaddir/$toolchainartifact_name-$toolchainartifact_version.tgz
+    message "Downloading toolchain artifact from $toolchainartifact_url"
+    wget -nc $toolchainartifact_url -O $downloaddir/$toolchainartifact_name-$toolchainartifact_version.tgz
 
-  if [ $? -gt 1 ]; then
-    die "Toolchain artifact download failed."
-  fi
+    if [ $? -gt 1 ]; then
+        die "Toolchain artifact download failed."
+    fi
 }
 
 extract-toolchain-artifact() {
-  rm -rf $TC_PREFIX_DIR
-  mkdir -p $TC_PREFIX_DIR
+    rm -rf $TC_PREFIX_DIR
+    mkdir -p $TC_PREFIX_DIR
 
-  cd $TC_PREFIX_DIR
-  message "Extracting toolchain artifact $toolchainartifact_name-$toolchainartifact_version.tgz"
-  tar xf $downloaddir/$toolchainartifact_name-$toolchainartifact_version.tgz
+    cd $TC_PREFIX_DIR
+    message "Extracting toolchain artifact $toolchainartifact_name-$toolchainartifact_version.tgz"
+    tar xf $downloaddir/$toolchainartifact_name-$toolchainartifact_version.tgz
 
-  if [ $? -gt 0 ]; then
-    die "Toolchain artifact extraction failed."
-  fi
+    if [ $? -gt 0 ]; then
+        die "Toolchain artifact extraction failed."
+    fi
 }
 
 save-settings () {
@@ -89,16 +89,16 @@ save-settings () {
 
 checkout-toolchain() {
     if [ ! -f $toolchaindir/ct-ng.in ]; then
-	message 'Cloning toolchain build tool from the toolchain repository.'
-	message "Repo URL: $tcuri"
-	git clone $tcuri $toolchaindir
-	#+
-	# TODO: It is possible that the previous clone failed. Might want to use
-	# git again to update just in case.
-	#-
-	if [ $? -gt 0 ]; then
-	    die "Cloning the toolchain encountered an error."
-	fi
+        message 'Cloning toolchain build tool from the toolchain repository.'
+        message "Repo URL: $tcuri"
+        git clone $tcuri $toolchaindir
+        #+
+        # TODO: It is possible that the previous clone failed. Might want to use
+        # git again to update just in case.
+        #-
+        if [ $? -gt 0 ]; then
+            die "Cloning the toolchain encountered an error."
+        fi
     fi
 
     cd $toolchaindir
@@ -109,47 +109,47 @@ checkout-toolchain() {
 
     run git checkout $toolchainversion
     if [ $? -ne 0 ]; then
-	die "Attempted to checkout the toolchain build tool using an invalid ID: $toolchainversion"
+        die "Attempted to checkout the toolchain build tool using an invalid ID: $toolchainversion"
     fi
     #+
     # If on a branch then pull the latest changes.
     #-
     run_ignore git symbolic-ref --short HEAD
     if [ $? -eq 0 ]; then
-	message Updating from branch: $toolchainversion
-	run git pull
+        message Updating from branch: $toolchainversion
+        run git pull
     else
-	message Toolchain version $toolchainversion is not a branch. Not updating.
+        message Toolchain version $toolchainversion is not a branch. Not updating.
     fi
 
 }
 
 install-toolchain-from-artifact(){
-  toolchainversion="$toolchainartifact_name-$toolchainartifact_version"
-  set-defaults
-  download-toolchain-artifact
+    toolchainversion="$toolchainartifact_name-$toolchainartifact_version"
+    set-defaults
+    download-toolchain-artifact
 
-  export TC_ARCH_SUFFIX=-$toolchainversion
-  export TC_PREFIX=$toolchainprefix
-  export TC_PREFIX_DIR=$toolchaindir/variations/$toolchainversion
-  export TC_LOCAL_TARBALLS_DIR=$downloaddir
-  message "TC_ARCH_SUFFIX: $TC_ARCH_SUFFIX"
-  message "TC_PREFIX_DIR: $TC_PREFIX_DIR"
-  message "TC_LOCAL_TARBALLS_DIR: $TC_LOCAL_TARBALLS_DIR"
+    export TC_ARCH_SUFFIX=-$toolchainversion
+    export TC_PREFIX=$toolchainprefix
+    export TC_PREFIX_DIR=$toolchaindir/variations/$toolchainversion
+    export TC_LOCAL_TARBALLS_DIR=$downloaddir
+    message "TC_ARCH_SUFFIX: $TC_ARCH_SUFFIX"
+    message "TC_PREFIX_DIR: $TC_PREFIX_DIR"
+    message "TC_LOCAL_TARBALLS_DIR: $TC_LOCAL_TARBALLS_DIR"
 
-  toolchainversionchanged=false
-  if [ "`cat $toolchaindir/.toolchaincache | tr -d "\012"`" != "$toolchainartifact_name-$toolchainartifact_version" ]; then
-    message "Toolchain artifact version changed or initial run"
-    toolchainversionchanged=true
-  fi
+    toolchainversionchanged=false
+    if [ "`cat $toolchaindir/.toolchaincache | tr -d "\012"`" != "$toolchainartifact_name-$toolchainartifact_version" ]; then
+        message "Toolchain artifact version changed or initial run"
+        toolchainversionchanged=true
+    fi
 
-  if [ ! -d "$TC_PREFIX_DIR" ] || [ $toolchainversionchanged = true ] ; then
-    extract-toolchain-artifact
-  else
-    message "Toolchain artifact already extracted... Skipping"
-  fi
+    if [ ! -d "$TC_PREFIX_DIR" ] || [ $toolchainversionchanged = true ] ; then
+        extract-toolchain-artifact
+    else
+        message "Toolchain artifact already extracted... Skipping"
+    fi
 
-  echo $toolchainartifact_name-$toolchainartifact_version > $toolchaindir/.toolchaincache
+    echo $toolchainartifact_name-$toolchainartifact_version > $toolchaindir/.toolchaincache
 }
 
 install-toolchain-from-source() {
@@ -162,25 +162,25 @@ install-toolchain-from-source() {
     message "Toolchain Make Args $makeargs"
 
     if [ -n "$dryrun" ]; then
-	    message "Just a test run -- not building the toolchain."
+        message "Just a test run -- not building the toolchain."
 
-	    make -f Makefile-toolchain  -C $toolchaindir -n $makeargs
+        make -f Makefile-toolchain  -C $toolchaindir -n $makeargs
     else
         make -f Makefile-toolchain  -C $toolchaindir $makeargs
 
         if [ $? -gt 0 ]; then
-	        die "The toolchain build failed."
+            die "The toolchain build failed."
         fi
     fi
 }
 
 set-defaults(){
     if [ -n "$toolchainreset" ]; then
-	for d in tcconfig tcuri toolchaindir toolchainprefix toolchainversion
-	do
-	    verbose Resetting default: $d
-	    reset_build_default $d
-	done
+        for d in tcconfig tcuri toolchaindir toolchainprefix toolchainversion
+        do
+            verbose Resetting default: $d
+            reset_build_default $d
+        done
     fi
     tcconfigdefault=$(get_build_default tcconfig $PWD/configs/mistify-tc-multilib.config)
     tcuridefault=$(get_build_default tcuri git@github.com:mistifyio/crosstool-ng.git)
@@ -192,26 +192,26 @@ set-defaults(){
     # Determine the location of the toolchain directory.
     #-
     if [ -z "$toolchaindir" ]; then
-	toolchaindir=$toolchaindirdefault
+        toolchaindir=$toolchaindirdefault
     fi
     message "Using toolchain located at: $toolchaindir"
     #+
     # Determine the toolchain variation to use.
     #-
     if [ -z "$toolchainprefix" ]; then
-	toolchainprefix=$toolchainprefixdefault
+        toolchainprefix=$toolchainprefixdefault
     fi
     message "Using toolchain variation: $toolchainprefix"
     #+
     # Determine the uri to use to fetch the toolchain source.
     #-
     if [ -z "$tcuri" ]; then
-	tcuri=$tcuridefault
+        tcuri=$tcuridefault
     fi
     message "The toolchain build tool repository is: $tcuri"
 
     if [ -z "$toolchainversion" ]; then
-	toolchainversion=$toolchainversiondefault
+        toolchainversion=$toolchainversiondefault
     fi
     # This is also used by install-go.
     message "The toolchain version is: $toolchainversion"
@@ -220,7 +220,7 @@ set-defaults(){
     # Setup the correct toolchain config file.
     #-
     if [ -z "$tcconfig" ]; then
-	tcconfig=$tcconfigdefault
+        tcconfig=$tcconfigdefault
     fi
     message "The toolchain config file is: $tcconfig"
 
@@ -253,42 +253,42 @@ install-toolchain () {
     toolchainbuilt=$TC_PREFIX_DIR/../.$toolchainversion-built
 
     if [[ "$target" == "toolchain-menuconfig" ]]; then
-	cd $toolchaindir
-	if [ ! -f $ctng ]; then
-	    config-toolchain $toolchaindir
-	fi
-	$ctng menuconfig
-	if [[ ! -f $tcconfig || $tcc -nt $tcconfig ]]; then
-	    ls -l $tcc $tcconfig
-	    cp $tcc $tcconfig
-	    if [ $? -gt 0 ]; then
-		die "Failed to save $tcconfig"
-	    else
-		rm $toolchainbuilt
-		message "Toolchain config file has been saved to: $tcconfig"
-		message "Run ./buildmistify to rebuild the toolchain."
-	    fi
-	fi
-	exit 0
+        cd $toolchaindir
+        if [ ! -f $ctng ]; then
+            config-toolchain $toolchaindir
+        fi
+        $ctng menuconfig
+        if [[ ! -f $tcconfig || $tcc -nt $tcconfig ]]; then
+            ls -l $tcc $tcconfig
+            cp $tcc $tcconfig
+            if [ $? -gt 0 ]; then
+            die "Failed to save $tcconfig"
+            else
+            rm $toolchainbuilt
+            message "Toolchain config file has been saved to: $tcconfig"
+            message "Run ./buildmistify to rebuild the toolchain."
+            fi
+        fi
+        exit 0
     fi
     if [ -f $tcc ]; then
-	if [ -f $tcconfig ]; then
-	    diff $tcconfig $tcc >/dev/null
-	    if [ $? -gt 0 ]; then
-		warning "The toolchain configuration has changed -- rebuilding the toolchain."
-		rm -f $toolchainbuilt
-	    fi
-	else
-	    error "The toolchain config file doesn't exist."
-	    die "Run ./buildmistify toolchain-menuconfig."
-	fi
+        if [ -f $tcconfig ]; then
+            diff $tcconfig $tcc >/dev/null
+            if [ $? -gt 0 ]; then
+                warning "The toolchain configuration has changed -- rebuilding the toolchain."
+                rm -f $toolchainbuilt
+            fi
+        else
+            error "The toolchain config file doesn't exist."
+            die "Run ./buildmistify toolchain-menuconfig."
+        fi
     fi
     #+
     # Don't build the toolchain if it has already been built.
     #-
     if [ -f $toolchainbuilt ]; then
-	    message "Using toolchain installed at: $TC_PREFIX_DIR"
-	    return 0
+        message "Using toolchain installed at: $TC_PREFIX_DIR"
+        return 0
     fi
     #+
     # Download, build and install the toolchain.
@@ -297,11 +297,11 @@ install-toolchain () {
     message "Installing toolchain to: $TC_PREFIX_DIR"
 
     if [ -n "$dryrun" ]; then
-	message "Just a test run -- not building the toolchain."
-	verbose "$ctng build"
+        message "Just a test run -- not building the toolchain."
+        verbose "$ctng build"
     else
-	build-toolchain
-	save-settings
+        build-toolchain
+        save-settings
     fi
     return 0
 }

--- a/scripts/mistify-functions.sh
+++ b/scripts/mistify-functions.sh
@@ -52,13 +52,13 @@ function reset_build_default() {
 function init_build_variable() {
     # Parameters:
     #	1: variable name and default value pair delimited by the delimeter (2)
-    #   2: an optional delimeter character (defaults to ';')
+    #   2: an optional delimeter character (defaults to '=')
     if [ -z "$2" ]; then
         d='='
     else
         d=$2
     fi
-    e=(`echo $1 | tr $d " "`)
+    e=(`echo "$1" | tr "$d" " "`)
     verbose ""
     verbose State variable default: "${e[0]} = ${e[1]}"
     eval val=\$${e[0]}
@@ -81,7 +81,7 @@ function init_build_variable() {
 function clear_build_variable() {
     # Parameters:
     #	1: variable name and default value pair delimited by the delimeter (2)
-    #   2: an optional delimeter character (defaults to ';')
+    #   2: an optional delimeter character (defaults to '=')
     if [ -z "$2" ]; then
         d='='
     else

--- a/scripts/mistify-functions.sh
+++ b/scripts/mistify-functions.sh
@@ -17,11 +17,12 @@ function get_build_default() {
     #   1: option name
     #   2: default value
     if [ -e $statedir/$1 ]; then
-      r=`cat $statedir/$1`
+        r=`cat $statedir/$1`
     else
-      r=$2
+        verbose Setting ${e[0]} to default: ${e[1]}
+        r=$2
     fi
-    verbose The default for $1 is $2
+    verbose The variable $1 equals $2
     echo $r
 }
 
@@ -29,6 +30,10 @@ function set_build_default() {
     # Parameters:
     #   1: option name
     #   2: value
+    if [ ! -d $statedir ]; then
+        verbose Creating the state directory: $statedir
+        mkdir -p $statedir
+    fi
     echo "$2">$statedir/$1
     verbose The default $1 has been set to $2
 }
@@ -40,8 +45,52 @@ function reset_build_default() {
         rm $statedir/$1
         verbose Option $1 default has been reset.
     else
-        verbose Option $1 has not been set.
+        verbose Option $1 default has not been set.
     fi
+}
+
+function init_build_variable() {
+    # Parameters:
+    #	1: variable name and default value pair delimited by the delimeter (2)
+    #   2: an optional delimeter character (defaults to ';')
+    if [ -z "$2" ]; then
+        d='='
+    else
+        d=$2
+    fi
+    e=(`echo $1 | tr $d " "`)
+    verbose ""
+    verbose State variable default: "${e[0]} = ${e[1]}"
+    eval val=\$${e[0]}
+    if [ -z "$val" ]; then
+        eval ${e[0]}=$(get_build_default ${e[0]} ${e[1]})
+    else
+        if [ "$val" = "default" ]; then
+            verbose Setting ${e[0]} to default: ${e[1]}
+            eval ${e[0]}=${e[1]}
+        else
+            eval ${e[0]}=$val
+        fi
+    fi
+    eval val=\$${e[0]}
+    verbose "State variable: ${e[0]} = $val"
+    verbose Saving current settings.
+    set_build_default ${e[0]} $val
+}
+
+function clear_build_variable() {
+    # Parameters:
+    #	1: variable name and default value pair delimited by the delimeter (2)
+    #   2: an optional delimeter character (defaults to ';')
+    if [ -z "$2" ]; then
+        d=';'
+    else
+        d=$2
+    fi
+    e=(`echo $1 | tr $d " "`)
+    verbose ""
+    verbose Clearing state variable: ${e[0]}
+    reset_build_default ${e[0]}
 }
 
 

--- a/scripts/mistify-functions.sh
+++ b/scripts/mistify-functions.sh
@@ -83,11 +83,11 @@ function clear_build_variable() {
     #	1: variable name and default value pair delimited by the delimeter (2)
     #   2: an optional delimeter character (defaults to ';')
     if [ -z "$2" ]; then
-        d=';'
+        d='='
     else
         d=$2
     fi
-    e=(`echo $1 | tr $d " "`)
+    e=(`echo "$1" | tr "$d" " "`)
     verbose ""
     verbose Clearing state variable: ${e[0]}
     reset_build_default ${e[0]}

--- a/scripts/mistify-functions.sh
+++ b/scripts/mistify-functions.sh
@@ -1,7 +1,7 @@
 #+
 # Some standard functions for Mistify-OS scripts.
 #-
-projectdir=$PWD	# Save this directory for later.
+projectdir=$PWD    # Save this directory for later.
 # Where to maintain buildmistify settings.
 statedir=$projectdir/.buildmistify
 
@@ -37,10 +37,10 @@ function reset_build_default() {
     # Parameters:
     #   1: option name
     if [ -e $statedir/$1 ]; then
-      rm $statedir/$1
-      verbose Option $1 default has been reset.
+        rm $statedir/$1
+        verbose Option $1 default has been reset.
     else
-      verbose Option $1 has not been set.
+        verbose Option $1 has not been set.
     fi
 }
 
@@ -72,7 +72,7 @@ error () {
 
 verbose () {
     if [[ "$verbose" == "y" ]]; then
-	echo >&2 -e "$lightblue$id$nc: $*"
+        echo >&2 -e "$lightblue$id$nc: $*"
     fi
 }
 
@@ -96,12 +96,12 @@ function run_ignore {
 function confirm () {
     read -r -p "${1:-Are you sure? [y/N]} " response
     case $response in
-	[yY][eE][sS]|[yY])
-	    true
-	    ;;
-	*)
-	    false
-	    ;;
+        [yY][eE][sS]|[yY])
+            true
+            ;;
+        *)
+            false
+            ;;
     esac
 }
 
@@ -109,4 +109,3 @@ is_mounted () {
     mount | grep $1
     return $?
 }
-


### PR DESCRIPTION
For maintainers one of the biggest difference is ALL defaults are in
one location now. Also all options can be individually reset to their default value
by simply using "default" for the option.

(copied from the last commit)
- All of the variables for buildmistify command line options and their
defaults have been moved to a single location in the buildmistify
script. This includes the toolchain and go related options.
- A single function now tests variables and sets defaults if not
specified on the command line.
- The install-toolchain.sh script has been modified to use only the
makefile to build the toolchain.
- The install-toolchain.sh script has also been modified to automatically
detect and install a prebuilt toolchain if it's corresponding tar file
exists in the download directory.
- Toolchains installed from tar files are installed in the same location
as if they had been built. This means the net effect of building a toolchain
or installing it from a tar file is virtually the same as far as buildroot
is concerned. NOTE: buildroot copies the toolchain from this location into
the build tree. Because of this it is necessary to do a complete build when
using a different toolchain.
- Makefile-toolchain has been rewritten to use the same variable names
as the buildmistify and install-toolchain scripts. It has also been revised
to use actual target files for dependencies rather than touching files to
indicate completed steps.

Many of these features have been tested along with their corner cases.
However, Jenkins jobs need to be examined and updated if necessary. Also,
there are a number of targets in Makefile-toolchain which haven't been tested
because they are not used from buildmistify.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-os/154)
<!-- Reviewable:end -->
