### PR TITLE
Set GO15VENDOREXPERIMENT=0 when building docker/distribution

### DIFF
--- a/package/mistify/docker-docker/docker-docker.mk
+++ b/package/mistify/docker-docker/docker-docker.mk
@@ -53,6 +53,7 @@ define DOCKER_DOCKER_BUILD_CMDS
 		&& GOPATH=$(GOPATH)/src/$(REGISTRY_IMPORT)/Godeps/_workspace:$(GOPATH) \
 		GOROOT=$(GOROOT) \
 		PATH=$(GOROOT)/bin:$(PATH) \
+		GO15VENDOREXPERIMENT=0 \
 		go build -o $(GOPATH)/bin/registry-v2 \
 			$(REGISTRY_IMPORT)/cmd/registry
 


### PR DESCRIPTION
References https://github.com/mistifyio/mistify/issues/43#issuecomment-191443169

This fixes an issue with import paths:

imports github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar:
must be imported as src/code.google.com/p/go/src/pkg/archive/tar

Go version 1.6 enables GOVENDOREXPERIMENT by default, which changes
packages in a vendor directory are imported. Later versions of
docker/distribution have this issue fixed, but for now, disabling
GOVENDOREXPERIMENT for this specific package build fixes the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-os/169)
<!-- Reviewable:end -->
